### PR TITLE
feat: Update webapp interface language to zh-TW (繁體中文)

### DIFF
--- a/japanese-alchemy-webapp/app/auth/page.tsx
+++ b/japanese-alchemy-webapp/app/auth/page.tsx
@@ -32,7 +32,7 @@ export default function AuthPage() {
       }
       router.push('/');
     } catch (err: any) {
-      setError(err.message || 'An error occurred');
+      setError(err.message || '發生錯誤');
     } finally {
       setLoading(false);
     }
@@ -46,7 +46,7 @@ export default function AuthPage() {
       await signInWithGoogle();
       router.push('/');
     } catch (err: any) {
-      setError(err.message || 'An error occurred');
+      setError(err.message || '發生錯誤');
     } finally {
       setLoading(false);
     }
@@ -57,10 +57,10 @@ export default function AuthPage() {
       <Card className="w-full max-w-md">
         <CardHeader className="text-center">
           <CardTitle className="text-3xl font-bold text-indigo-600 dark:text-indigo-400">
-            Japanese Alchemy
+            J-Buddy: Learning Hub
           </CardTitle>
           <CardDescription className="text-lg">
-            {isSignUp ? 'Create an account' : 'Sign in to your account'}
+            {isSignUp ? '建立帳號' : '登入你的帳號'}
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
@@ -72,7 +72,7 @@ export default function AuthPage() {
 
           <form onSubmit={handleSubmit} className="space-y-4">
             <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
+              <Label htmlFor="email">電子郵件</Label>
               <Input
                 id="email"
                 type="email"
@@ -85,7 +85,7 @@ export default function AuthPage() {
             </div>
             
             <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
+              <Label htmlFor="password">密碼</Label>
               <Input
                 id="password"
                 type="password"
@@ -99,7 +99,7 @@ export default function AuthPage() {
             </div>
 
             <Button type="submit" className="w-full" disabled={loading}>
-              {loading ? 'Loading...' : isSignUp ? 'Sign Up' : 'Sign In'}
+              {loading ? '載入中...' : isSignUp ? '註冊' : '登入'}
             </Button>
           </form>
 
@@ -109,7 +109,7 @@ export default function AuthPage() {
             </div>
             <div className="relative flex justify-center text-xs uppercase">
               <span className="bg-background px-2 text-muted-foreground">
-                Or continue with
+                或使用以下方式繼續
               </span>
             </div>
           </div>
@@ -150,8 +150,8 @@ export default function AuthPage() {
               disabled={loading}
             >
               {isSignUp
-                ? 'Already have an account? Sign in'
-                : "Don't have an account? Sign up"}
+                ? '已有帳號？登入'
+                : '還沒有帳號？註冊'}
             </button>
           </div>
         </CardContent>

--- a/japanese-alchemy-webapp/app/layout.tsx
+++ b/japanese-alchemy-webapp/app/layout.tsx
@@ -4,8 +4,8 @@ import { AuthProvider } from "@/contexts/AuthContext";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 
 export const metadata: Metadata = {
-  title: "Japanese Alchemy - Vocabulary & Grammar Study",
-  description: "A Japanese vocabulary and grammar study application built with Next.js, shadcn/ui, and Firebase",
+  title: "J-Buddy: Learning Hub - 單字與文法學習",
+  description: "一個使用 Next.js、shadcn/ui 和 Firebase 構建的日語單字與文法學習應用程式",
 };
 
 export default function RootLayout({
@@ -14,7 +14,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang="zh-Hant" suppressHydrationWarning>
       <head>
         <link rel="stylesheet" href="https://static.line-scdn.net/seed/line-seed/2.0/LineSeedJP_TTF_Rg.css" />
       </head>

--- a/japanese-alchemy-webapp/app/page.tsx
+++ b/japanese-alchemy-webapp/app/page.tsx
@@ -36,7 +36,7 @@ function safeSourceUrl(value: string): string | null {
 function SharedBadge() {
   return (
     <span className="inline-flex items-center rounded-full bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
-      Shared
+      共享
     </span>
   );
 }
@@ -58,7 +58,7 @@ function SharedSourceAttribution({ metadata }: { metadata?: { source_text?: stri
           rel="noopener noreferrer"
           className="text-primary hover:underline"
         >
-          Source
+          來源
         </a>
       )}
     </div>
@@ -142,7 +142,7 @@ export default function Dashboard() {
   if (loading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="text-lg">Loading...</div>
+        <div className="text-lg">載入中...</div>
       </div>
     );
   }
@@ -156,7 +156,7 @@ export default function Dashboard() {
       <header className="bg-card border-b shadow-sm">
         <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
           <h1 className="text-2xl font-bold text-primary">
-            Japanese Alchemy
+            J-Buddy: Learning Hub
           </h1>
           <div className="flex items-center gap-4">
             {user ? (
@@ -166,14 +166,14 @@ export default function Dashboard() {
                 </span>
                 <ThemeToggle />
                 <Button onClick={handleSignOut} variant="outline" size="sm">
-                  Sign Out
+                  登出
                 </Button>
               </>
             ) : (
               <>
                 <ThemeToggle />
                 <Button onClick={handleSignIn} variant="default" size="sm">
-                  Sign In
+                  登入
                 </Button>
               </>
             )}
@@ -186,27 +186,27 @@ export default function Dashboard() {
         <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-6">
           <TabsList className={`grid w-full max-w-xl ${user ? 'grid-cols-4' : 'grid-cols-3'}`}>
             <TabsTrigger value="vocabularies">
-              Vocabularies ({allVocabularies.length})
+              單字 ({allVocabularies.length})
             </TabsTrigger>
             <TabsTrigger value="grammars">
-              Grammars ({allGrammars.length})
+              文法 ({allGrammars.length})
             </TabsTrigger>
             {user && (
               <TabsTrigger value="pages">
-                Pages ({analysisPages.length})
+                頁面 ({analysisPages.length})
               </TabsTrigger>
             )}
             <TabsTrigger value="shared-pages">
-              Shared Pages ({sharedAnalysisPages.length})
+              共享頁面 ({sharedAnalysisPages.length})
             </TabsTrigger>
           </TabsList>
 
           {/* Vocabularies Tab */}
           <TabsContent value="vocabularies" className="space-y-4">
             <div>
-              <h2 className="text-2xl font-bold">{user ? 'My Vocabularies' : 'Shared Vocabularies'}</h2>
+              <h2 className="text-2xl font-bold">{user ? '我的單字' : '共享單字'}</h2>
               <p className="text-muted-foreground">
-                {user ? 'View your Japanese vocabulary collection' : 'Browse Japanese vocabulary shared by the community'}
+                {user ? '查看你的日語單字收藏' : '瀏覽社群共享的日語單字'}
               </p>
             </div>
 
@@ -214,7 +214,7 @@ export default function Dashboard() {
               {allVocabularies.length === 0 ? (
                 <Card className="col-span-full">
                   <CardContent className="py-8 text-center">
-                    <p className="text-gray-500">No vocabularies found.</p>
+                    <p className="text-gray-500">找不到單字。</p>
                   </CardContent>
                 </Card>
               ) : (
@@ -229,7 +229,7 @@ export default function Dashboard() {
                         />
                       </div>
                       <CardDescription>
-                        {new Date(vocab.createdAt).toLocaleDateString()}
+                        {new Date(vocab.createdAt).toLocaleDateString("zh-TW")}
                       </CardDescription>
                       {vocab.isShared && <SharedSourceAttribution metadata={vocab.metadata} />}
                     </CardHeader>
@@ -248,9 +248,9 @@ export default function Dashboard() {
           {/* Grammars Tab */}
           <TabsContent value="grammars" className="space-y-4">
             <div>
-              <h2 className="text-2xl font-bold">{user ? 'My Grammars' : 'Shared Grammars'}</h2>
+              <h2 className="text-2xl font-bold">{user ? '我的文法' : '共享文法'}</h2>
               <p className="text-muted-foreground">
-                {user ? 'View your Japanese grammar points' : 'Browse Japanese grammar points shared by the community'}
+                {user ? '查看你的日語文法重點' : '瀏覽社群共享的日語文法重點'}
               </p>
             </div>
 
@@ -258,7 +258,7 @@ export default function Dashboard() {
               {allGrammars.length === 0 ? (
                 <Card>
                   <CardContent className="py-8 text-center">
-                    <p className="text-gray-500">No grammar points found.</p>
+                    <p className="text-gray-500">找不到文法重點。</p>
                   </CardContent>
                 </Card>
               ) : (
@@ -273,7 +273,7 @@ export default function Dashboard() {
                         />
                       </div>
                       <CardDescription>
-                        {new Date(grammar.createdAt).toLocaleDateString()}
+                        {new Date(grammar.createdAt).toLocaleDateString("zh-TW")}
                       </CardDescription>
                       {grammar.isShared && <SharedSourceAttribution metadata={grammar.metadata} />}
                     </CardHeader>
@@ -293,9 +293,9 @@ export default function Dashboard() {
           {user && (
             <TabsContent value="pages" className="space-y-4">
               <div>
-                <h2 className="text-2xl font-bold">My Pages</h2>
+                <h2 className="text-2xl font-bold">我的頁面</h2>
                 <p className="text-muted-foreground">
-                  Browse your saved analysis pages
+                  瀏覽你儲存的分析頁面
                 </p>
               </div>
 
@@ -303,7 +303,7 @@ export default function Dashboard() {
                 {analysisPages.length === 0 ? (
                   <Card>
                     <CardContent className="py-8 text-center">
-                      <p className="text-gray-500">No analysis pages found.</p>
+                      <p className="text-gray-500">找不到分析頁面。</p>
                     </CardContent>
                   </Card>
                 ) : (
@@ -319,11 +319,11 @@ export default function Dashboard() {
                               dangerouslySetInnerHTML={{ __html: parseFurigana(page.source_text) }}
                             />
                             <Button variant="destructive" size="sm" onClick={() => handleDeleteAnalysisPage(page.id)}>
-                              Delete
+                              刪除
                             </Button>
                           </div>
                           <CardDescription>
-                            {new Date(page.createdAt).toLocaleDateString()}
+                            {new Date(page.createdAt).toLocaleDateString("zh-TW")}
                             {sourceUrl && (
                               <a
                                 href={sourceUrl}
@@ -331,7 +331,7 @@ export default function Dashboard() {
                                 rel="noopener noreferrer"
                                 className="ml-2 text-primary hover:underline"
                               >
-                                Source
+                                來源
                               </a>
                             )}
                           </CardDescription>
@@ -352,9 +352,9 @@ export default function Dashboard() {
 
           <TabsContent value="shared-pages" className="space-y-4">
             <div>
-              <h2 className="text-2xl font-bold">Shared Pages</h2>
+              <h2 className="text-2xl font-bold">共享頁面</h2>
               <p className="text-muted-foreground">
-                Browse analysis pages shared by other learners
+                瀏覽其他學習者共享的分析頁面
               </p>
             </div>
 
@@ -362,7 +362,7 @@ export default function Dashboard() {
               {sharedAnalysisPages.length === 0 ? (
                 <Card>
                   <CardContent className="py-8 text-center">
-                    <p className="text-gray-500">No shared analysis pages found.</p>
+                    <p className="text-gray-500">找不到共享分析頁面。</p>
                   </CardContent>
                 </Card>
               ) : (
@@ -377,7 +377,7 @@ export default function Dashboard() {
                           dangerouslySetInnerHTML={{ __html: parseFurigana(page.source_text) }}
                         />
                         <CardDescription>
-                          {new Date(page.createdAt).toLocaleDateString()}
+                          {new Date(page.createdAt).toLocaleDateString("zh-TW")}
                           {sourceUrl && (
                             <a
                               href={sourceUrl}
@@ -385,7 +385,7 @@ export default function Dashboard() {
                               rel="noopener noreferrer"
                               className="ml-2 text-primary hover:underline"
                             >
-                              Source
+                              來源
                             </a>
                           )}
                         </CardDescription>

--- a/japanese-alchemy-webapp/components/ui/dialog.tsx
+++ b/japanese-alchemy-webapp/components/ui/dialog.tsx
@@ -72,7 +72,7 @@ function DialogContent({
             className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4"
           >
             <XIcon />
-            <span className="sr-only">Close</span>
+            <span className="sr-only">關閉</span>
           </DialogPrimitive.Close>
         )}
       </DialogPrimitive.Content>

--- a/japanese-alchemy-webapp/components/ui/theme-toggle.tsx
+++ b/japanese-alchemy-webapp/components/ui/theme-toggle.tsx
@@ -26,11 +26,11 @@ export function ThemeToggle() {
       size="icon"
       onClick={toggleTheme}
       className="rounded-full"
-      title={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
+      title={isDark ? '切換至淺色模式' : '切換至深色模式'}
     >
       <Sun className="h-5 w-5 rotate-0 scale-100 transition-all dark:-rotate-90 dark:scale-0" />
       <Moon className="absolute h-5 w-5 rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />
-      <span className="sr-only">Toggle theme</span>
+      <span className="sr-only">切換主題</span>
     </Button>
   );
 }


### PR DESCRIPTION
## Summary

Translate all user-facing UI strings in the Next.js webapp from English to 繁體中文 (zh-TW), and rebrand the product from "Japanese Alchemy" to "J-Buddy: Learning Hub".

**Plan:** `docs/plans/2026-08-28-2212-feat-webapp-zh-tw-localization-plan.md`

## Changes

- **`app/page.tsx`** — 27 dashboard UI strings translated (tabs, headings, descriptions, empty states, buttons, badges, links); brand updated to "J-Buddy: Learning Hub"; all `toLocaleDateString()` calls switched to `zh-TW` locale
- **`app/auth/page.tsx`** — 12 auth page strings translated (labels, buttons, toggle link, divider, fallback error); brand updated; "Google" left unchanged as a brand name
- **`components/ui/theme-toggle.tsx`** — `title` and `sr-only` accessibility strings translated (切換主題, 切換至淺色模式, 切換至深色模式)
- **`components/ui/dialog.tsx`** — `sr-only` close button text translated (關閉)
- **`app/layout.tsx`** — `<html lang>` set to `zh-Hant`; metadata `title` and `description` translated to zh-TW with new brand name

## Key Decisions

- **Direct string replacement, no i18n framework** — single-language target, no existing i18n infrastructure to extend
- **Brand name: "J-Buddy: Learning Hub"** — user-specified replacement for "Japanese Alchemy", applied uniformly
- **`zh-Hant` for HTML lang, `zh-TW` for locale APIs** — BCP 47 convention: script tag for document language, region tag for `toLocaleDateString()`

## Testing

- `npm run build` — ✓ compiled successfully, TypeScript passed, 5 static pages generated
- `npm run test` — ✓ 10/10 tests passed (no logic changes; existing tests unaffected)
- `npm run lint` — 3 pre-existing errors + 1 warning (unchanged by this work; no new lint issues introduced)
- Code review: skipped (mechanical diff — 45 insertions/45 deletions, all pure string literal replacements with no behavioral change)

## Post-Deploy Monitoring & Validation

No runtime behavior change — all modifications are static string literals and attribute values. Manual visual inspection recommended after deploy:
- Dashboard (authenticated + unauthenticated states) for correct zh-TW rendering
- Auth page (sign-in + sign-up modes) for correct zh-TW rendering
- Date formatting displays in zh-TW locale format (e.g. `2026/8/28`)
- Document `<title>` and meta description in page source