### PR TITLE
feat(webapp): publish to firebase hosting

### DIFF
--- a/japanese-alchemy-hosting/functions/README.md
+++ b/japanese-alchemy-hosting/functions/README.md
@@ -139,6 +139,34 @@ firebase functions:log
 
 **Note:** Functions are automatically deployed with secrets bound. The `JAPANESE_ALCHEMY_CONFIG` secret must exist in Secret Manager.
 
+### Webapp, Auth, and Firestore deployment
+
+The Next.js webapp is hosted separately at Firebase Hosting. Deploying functions
+does **not** deploy the Firestore rules used by the webapp.
+
+```bash
+cd japanese-alchemy-hosting
+
+# Required after changing firestore.rules, including shared-item read access
+firebase deploy --only firestore:rules
+```
+
+Shared analysis pages, vocabularies, and grammars are written by `saveItems`
+with the Admin SDK, then read directly by the webapp. If the deployed Firestore
+rules are stale, the save can succeed while the webapp shows no shared items
+with `FirebaseError: Missing or insufficient permissions.`
+
+Each Firebase Hosting site has its own domain. Before Google sign-in can work
+on a new site, add its hostname in **Firebase Console -> Authentication ->
+Settings -> Authorized domains**. For the current webapp site, add:
+
+```text
+japanese-alchemy-webapp.web.app
+```
+
+Enter the hostname only; do not include `https://` or a path. This change does
+not require a function or Hosting redeploy.
+
 ## Callable streaming safeguards
 
 `explainStreamCallable` validates the request, enforces the same Firestore-backed
@@ -285,7 +313,8 @@ users/
 - `explain`: Public function (no authentication required)
 - `explainStreamCallable`: Public callable stream (no authentication required)
 - `saveItems`: Requires Firebase Authentication
-- Firestore rules ensure users can only access their own data
+- Firestore rules restrict user data to its owner and allow read-only access to
+  published shared collections
 - API keys stored securely in Firebase Secret Manager
 
 ## Dependencies

--- a/japanese-alchemy-webapp/.firebaserc
+++ b/japanese-alchemy-webapp/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "japanese-alchemy"
+  }
+}

--- a/japanese-alchemy-webapp/.gitignore
+++ b/japanese-alchemy-webapp/.gitignore
@@ -10,6 +10,9 @@
 /.next/
 /out/
 
+# Firebase CLI deployment cache
+/.firebase/
+
 # Production
 /build
 

--- a/japanese-alchemy-webapp/README.md
+++ b/japanese-alchemy-webapp/README.md
@@ -275,67 +275,47 @@ npm run dev
 # Build for production
 npm run build
 
-# Start production server
-npm start
+# Preview the generated Firebase Hosting site locally
+npm run preview
 
 # Run linter
 npm run lint
 
 # Type check
-npm run type-check
+npx tsc --noEmit
 ```
 
 ## 🚀 Firebase Deployment
 
-### Option 1: Deploy to Firebase Hosting
+The webapp is deployed as a static Next.js export. Firebase Authentication,
+Firestore, and the existing Cloud Functions remain in the `japanese-alchemy`
+Firebase project; Firebase Hosting only serves the generated site.
 
-1. Install Firebase CLI (if not already installed):
+1. Install and authenticate the Firebase CLI (if needed):
    ```bash
    npm install -g firebase-tools
-   ```
-
-2. Login to Firebase:
-   ```bash
    firebase login
    ```
 
-3. Initialize Firebase in the project root (not in japanese-alchemy-webapp):
+2. Create the production environment file. The Firebase web configuration is
+   safe to expose in the browser; access is protected by Firebase Auth and
+   Firestore security rules.
    ```bash
-   cd ..
-   firebase init hosting
-   ```
-   
-   When prompted:
-   - Select your Firebase project
-   - Set the public directory to `japanese-alchemy-webapp/out`
-   - Configure as a single-page app: Yes
-   - Set up automatic builds: Yes
-
-4. Build the Next.js application:
-   ```bash
-   cd japanese-alchemy-webapp
-   npm run build
+   cp .env.local.example .env.local
    ```
 
-5. Deploy:
+3. Build and deploy from this directory:
    ```bash
-   firebase deploy
+   npm run deploy
    ```
 
-### Option 2: Deploy to Vercel (Recommended for Next.js)
+The configuration in `firebase.json` deploys the generated `out/` directory to
+the `japanese-alchemy-webapp` Hosting site. If you later add server-side
+rendering, API routes, or server-only secrets, move this webapp to Firebase App
+Hosting or Cloud Run instead of static Hosting.
 
-1. Push your code to GitHub
-2. Go to [Vercel](https://vercel.com)
-3. Import your repository
-4. Add environment variables in Vercel dashboard
-5. Deploy
-
-Vercel is recommended as it provides better support for Next.js features including:
-- Server-side rendering
-- API routes
-- Edge functions
-- Automatic HTTPS
-- CDN distribution
+For a different Firebase project, create a Hosting site first and replace the
+`site` value in `firebase.json` with its site ID.
 
 ## 🔒 Firestore Security Rules
 

--- a/japanese-alchemy-webapp/firebase.json
+++ b/japanese-alchemy-webapp/firebase.json
@@ -1,0 +1,12 @@
+{
+  "hosting": {
+    "site": "japanese-alchemy-webapp",
+    "public": "out",
+    "cleanUrls": true,
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**"
+    ]
+  }
+}

--- a/japanese-alchemy-webapp/next.config.ts
+++ b/japanese-alchemy-webapp/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // The webapp reads Firebase Auth and Firestore directly from the browser, so
+  // it can be published as static files on Firebase Hosting.
+  output: "export",
 };
 
 export default nextConfig;

--- a/japanese-alchemy-webapp/package.json
+++ b/japanese-alchemy-webapp/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "preview": "npm run build && firebase emulators:start --only hosting",
     "lint": "eslint",
-    "test": "vitest run"
+    "test": "vitest run",
+    "deploy": "npm run build && firebase deploy --only hosting"
   },
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",


### PR DESCRIPTION
## Summary

Publish the Next.js learning hub as a separate Firebase Hosting site. The site now builds a static export before deployment and keeps Hosting cache files out of Git.

Document the operational steps that keep the webapp connected to Firebase Authentication and shared Firestore data.

## Validation

- `npm run build` in `japanese-alchemy-webapp`
- Deployed to `https://japanese-alchemy-webapp.web.app`
- Verified `/` and `/auth` return HTTP 200
- `npm run lint` remains blocked by three pre-existing lint errors outside this change.

## Required Firebase configuration

- Add `japanese-alchemy-webapp.web.app` to Firebase Authentication authorized domains.
- Deploy current Firestore rules with `firebase deploy --only firestore:rules` from `japanese-alchemy-hosting`.

## Post-Deploy Monitoring & Validation

- Watch the browser console for `auth/unauthorized-domain` and `FirebaseError: Missing or insufficient permissions`.
- Healthy signal: Google sign-in succeeds and shared vocabulary, grammar, and page counts load.
- Mitigate failures by confirming the authorized domain and deploying the Firestore rules before retrying.
- Validate after each Firebase configuration change; no ongoing monitoring owner is assigned.
