### PR TITLE
fix(extension): separate analysis action from results

### DIFF
--- a/japanese-alchemy-chrome-extension/src/sidepanel/sidepanel.html
+++ b/japanese-alchemy-chrome-extension/src/sidepanel/sidepanel.html
@@ -479,6 +479,10 @@
       transition: all 0.2s ease-in-out;
     }
 
+    #analyzeButton {
+      margin-bottom: 8px;
+    }
+
     .save-for-later-btn:hover {
       background: var(--button-hover);
       transform: translateY(-1px);

--- a/japanese-alchemy-chrome-extension/tests/sidepanel.analysisModeMarkup.test.js
+++ b/japanese-alchemy-chrome-extension/tests/sidepanel.analysisModeMarkup.test.js
@@ -46,4 +46,8 @@ describe('sidepanel analysis-mode markup', () => {
     expect(html).toContain('hidden>停止分析</button>');
     expect(html).toContain('aria-label="停止目前分析"');
   });
+
+  test('separates the manual analysis action from the analysis result', () => {
+    expect(html).toMatch(/#analyzeButton\s*\{[\s\S]*?margin-bottom:\s*8px;/);
+  });
 });


### PR DESCRIPTION
The sidepanel now leaves a clear gap between the manual analysis action and its result. The result toolbar no longer touches the "開始分析" button.

Validated with the extension test suite (141 tests) and a browser layout measurement that confirms an 8px gap.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
