### PR TITLE
feat: add FAQ and website toolbar links

### DIFF
--- a/japanese-alchemy-chrome-extension/src/sidepanel/sidepanel.html
+++ b/japanese-alchemy-chrome-extension/src/sidepanel/sidepanel.html
@@ -291,7 +291,7 @@
       color: white;
     }
 
-    .theme-toggle {
+    .theme-toggle, .external-link-button {
       width: 36px;
       height: 36px;
       padding: 0;
@@ -306,12 +306,12 @@
       transition: all 0.2s ease-in-out;
     }
 
-    .theme-toggle:hover {
+    .theme-toggle:hover, .external-link-button:hover {
       border-color: var(--button-bg);
       background: var(--bg-secondary);
     }
 
-    .theme-toggle svg {
+    .theme-toggle svg, .external-link-button svg {
       width: 20px;
       height: 20px;
       transition: opacity 0.2s ease-in-out;
@@ -744,6 +744,19 @@
           </svg>
           <svg class="moon-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" style="display: none;">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
+          </svg>
+        </button>
+        <button class="external-link-button" id="websiteButton" type="button" title="前往網站" aria-label="前往網站">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <circle cx="12" cy="12" r="9" stroke-width="2"></circle>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 12h18M12 3c2.5 2.5 3.75 5.5 3.75 9S14.5 18.5 12 21c-2.5-2.5-3.75-5.5-3.75-9S9.5 5.5 12 3z"></path>
+          </svg>
+        </button>
+        <button class="external-link-button" id="faqButton" type="button" title="常見問題" aria-label="常見問題">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" aria-hidden="true">
+            <circle cx="12" cy="12" r="9" stroke-width="2"></circle>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.5 9a2.5 2.5 0 1 1 4.3 1.7c-.9.9-1.8 1.4-1.8 2.8"></path>
+            <path stroke-linecap="round" stroke-width="2" d="M12 17h.01"></path>
           </svg>
         </button>
         <!-- <button class="theme-toggle" id="configButton" title="Configuration">

--- a/japanese-alchemy-chrome-extension/src/sidepanel/sidepanel.js
+++ b/japanese-alchemy-chrome-extension/src/sidepanel/sidepanel.js
@@ -25,6 +25,12 @@ const ANALYSIS_ALLOWED_ATTR = ['colspan', 'href', 'rowspan', 'title'];
 const COMPLETED_ANALYSIS_RESULT_CACHE_VERSION = 1;
 const COMPLETED_ANALYSIS_RESULT_STORAGE_KEY = 'lastAnalysisResult';
 const CONTROLLED_CHECKBOX_PATTERN = /<input type="checkbox" name="(words|grammars)" value="([^"<>]*)">/g;
+export const WEBSITE_URL = 'https://japanese-alchemy-webapp.web.app/';
+export const FAQ_URL = 'https://japanese-alchemy-webapp.web.app/faq';
+
+export async function openExternalPage(url) {
+    await chrome.tabs.create({ url, active: true });
+}
 
 function getDomPurify() {
     // The production side panel always has a real browser window. The guarded
@@ -994,6 +1000,8 @@ async function initElements() {
   elements = {
     prose: document.querySelector('.prose'),
     themeToggle: document.querySelector('#themeToggle'),
+    websiteButton: document.querySelector('#websiteButton'),
+    faqButton: document.querySelector('#faqButton'),
     alertMessage: document.querySelector('#alertMessage'),
     copyButton: document.querySelector('.copy-button'),
     fontSizeBtn: document.querySelector('#fontSizeBtn'),
@@ -1134,7 +1142,7 @@ async function handleSignOut() {
 }
 
 // Set up event listeners
-async function setupEventListeners() {
+export async function setupEventListeners() {
     if (!elements) {
       console.log('[Sidebar] Initializing elements...');
       elements = await initElements();
@@ -1142,6 +1150,12 @@ async function setupEventListeners() {
 
     // Theme toggle
     elements.themeToggle?.addEventListener('click', () => handleThemeToggle(elements));
+    elements.websiteButton?.addEventListener('click', () => {
+      void openExternalPage(WEBSITE_URL);
+    });
+    elements.faqButton?.addEventListener('click', () => {
+      void openExternalPage(FAQ_URL);
+    });
 
     elements.analysisModeButtons?.forEach((button) => {
       button.addEventListener('click', async () => {

--- a/japanese-alchemy-chrome-extension/tests/sidepanel.externalLinks.test.js
+++ b/japanese-alchemy-chrome-extension/tests/sidepanel.externalLinks.test.js
@@ -1,0 +1,41 @@
+import {
+  FAQ_URL,
+  WEBSITE_URL,
+  openExternalPage,
+  setSidepanelElementsForTesting,
+  setupEventListeners,
+} from '../src/sidepanel/sidepanel.js';
+
+describe('sidepanel external links', () => {
+  beforeEach(() => {
+    global.chrome.tabs = { create: jest.fn(async () => undefined) };
+  });
+
+  test.each([
+    ['website', WEBSITE_URL, 'https://japanese-alchemy-webapp.web.app/'],
+    ['FAQ', FAQ_URL, 'https://japanese-alchemy-webapp.web.app/faq'],
+  ])('opens the %s destination in an active new tab', async (_name, destination, expectedUrl) => {
+    await openExternalPage(destination);
+
+    expect(global.chrome.tabs.create).toHaveBeenCalledWith({
+      url: expectedUrl,
+      active: true,
+    });
+  });
+
+  test('wires each toolbar button to its destination', async () => {
+    const websiteButton = { addEventListener: jest.fn() };
+    const faqButton = { addEventListener: jest.fn() };
+    setSidepanelElementsForTesting({ websiteButton, faqButton });
+
+    await setupEventListeners();
+
+    const websiteListener = websiteButton.addEventListener.mock.calls[0][1];
+    const faqListener = faqButton.addEventListener.mock.calls[0][1];
+    websiteListener();
+    faqListener();
+
+    expect(global.chrome.tabs.create).toHaveBeenNthCalledWith(1, { url: WEBSITE_URL, active: true });
+    expect(global.chrome.tabs.create).toHaveBeenNthCalledWith(2, { url: FAQ_URL, active: true });
+  });
+});

--- a/japanese-alchemy-webapp/app/faq/page.test.tsx
+++ b/japanese-alchemy-webapp/app/faq/page.test.tsx
@@ -1,0 +1,14 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+import FaqPage from './page';
+
+describe('FAQ page', () => {
+  it('renders public Traditional Chinese Gemini quota guidance expanded by default', () => {
+    const html = renderToStaticMarkup(<FaqPage />);
+
+    expect(html).toContain('常見問題');
+    expect(html).toContain('Gemini API error: Too Many Requests');
+    expect(html).toContain('Google Gemini 免費方案的 API 用量已達限制');
+    expect(html).toMatch(/<details open=""[^>]*>/);
+  });
+});

--- a/japanese-alchemy-webapp/app/faq/page.tsx
+++ b/japanese-alchemy-webapp/app/faq/page.tsx
@@ -1,0 +1,24 @@
+export default function FaqPage() {
+  return (
+    <main className="min-h-screen bg-gradient-to-br from-background via-background to-muted px-4 py-12">
+      <section className="mx-auto max-w-3xl">
+        <header className="mb-8 text-center">
+          <h1 className="text-3xl font-bold text-primary">常見問題</h1>
+          <p className="mt-3 text-muted-foreground">使用 J-Buddy 時的常見疑問與解答。</p>
+        </header>
+
+        <section className="rounded-xl border bg-card p-6 text-card-foreground shadow-sm">
+          <h2 className="mb-4 text-xl font-semibold">分析服務</h2>
+            <details open className="rounded-lg border bg-muted/30 px-4 py-3">
+              <summary className="cursor-pointer font-medium text-foreground">
+                點擊「開始分析」後出現「呼叫分析服務時發生錯誤：Gemini API error: Too Many Requests」怎麼辦？
+              </summary>
+              <p className="mt-3 leading-7 text-muted-foreground">
+                這代表 Google Gemini 免費方案的 API 用量已達限制。請稍候一段時間後再重新嘗試；限制重置時間由 Google 的配額規則決定，因此無法保證確切等待時間。
+              </p>
+            </details>
+        </section>
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
## What problem does this solve?

Learners can now reach J-Buddy help even when analysis is unavailable. The FAQ explains how to recover from Gemini free-tier quota errors without promising an unknown reset time.

Closes #50

Discord Discussion URL: N/A — the scope was agreed in issue #50.

## At a Glance

```
+------------------+
| Sidepanel toolbar |
+--------+---------+
         |
         v
+--------+---------+
| Browser tab      |
+--------+---------+
         |
         v
+--------+---------+
| Website / FAQ    |
+------------------+
```

## Prior Art & Industry Research

Not applicable — this is a small user-interface addition with no architectural, runtime, delivery, or persistence change.

## Proposed Solution

The sidepanel exposes compact Website and FAQ controls in its persistent toolbar. Both controls open the agreed public destinations in active tabs.

The webapp now has a public Traditional Chinese FAQ route. Its initial answer is expanded and uses the browser's native disclosure control.

## Why this approach?

The controls remain available before sign-in and while analysis is loading, so help is reachable in the failure state that needs it. Named destinations keep a future domain change local. Native disclosure keeps the first FAQ accessible without adding client-side state.

## Alternatives Considered

- Put the controls in the results toolbar. Rejected because an analysis error can occur before results exist.
- Promise a quota reset time. Rejected because Google determines the free-tier quota schedule.

## Validation

- [x] Extension `npm run test` passes (144 tests).
- [x] Extension `npm run build` passes.
- [x] Webapp `npm run test` passes (11 tests).
- [x] Webapp `npm run build` passes; it statically generates `/faq`.
- [x] `npm run check` — not available in either affected package.
- [x] Manual extension rendering — not run; the controls and tab behavior have targeted automated coverage.
