### PR TITLE
feat: add AWS Bedrock LLM provider

### DIFF
--- a/docs/plans/2026-09-06-1239-llm-fallback-chain-plan.md
+++ b/docs/plans/2026-09-06-1239-llm-fallback-chain-plan.md
@@ -1,0 +1,178 @@
+---
+title: Sequential LLM Fallback Chain
+date: 2026-09-06
+type: plan
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+product_contract_source: ce-brainstorm
+execution: code
+---
+
+## Goal Capsule
+
+**Objective:** Add a static, ordered LLM provider fallback chain so that when the active provider returns a 429 (rate limit) or 5xx (server error), the request automatically retries with the next provider in the chain before failing.
+
+**Means:** A new `LlmServiceChain` wrapper class that iterates through `["gemini", "zai"]` on retryable errors, integrated via the existing `createLlmService()` factory. No handler changes; telemetry stays unchanged; only logging captures the chain.
+
+**Stop when:** All three implementation units pass verification (compile, tests, smoke test) and the plan's Definition of Done is met.
+
+---
+
+## Product Contract
+
+### Problem Frame
+
+J-Buddy's Firebase Functions currently use a single hardcoded LLM provider (`gemini`). When that provider returns a 429 (rate limit exceeded) or 5xx (server error), the entire request fails with no recovery path. Both the batch `explain()` callable and the streaming `explainStreamCallable()` callable are affected. The two providers (Gemini and ZAI) use the same OpenAI-compatible `/chat/completions` protocol, making a transparent retry wrapper structurally safe.
+
+### Requirements
+
+**Single-Provider Retry**
+- R1. When `chatCompletion()` or `streamCompletion()` receives a 429 or 5xx from the current provider, retry with the next provider in the configured chain.
+- R2. Non-retryable errors (400 Bad Request, 401/403 Unauthorized, 404 Not Found, input validation failures) must propagate immediately without consuming the next provider.
+- R3. If all providers in the chain fail with retryable errors, throw the last provider's error (not a generic "all failed" message).
+
+**Retry Classification**
+- R4. Retryable errors are: Firebase `HttpsError` with status 429 or status 500-599; generic `Error` with network-related messages (ECONNRESET, ETIMEDOUT, ECONNREFUSED, ENOTFOUND, "fetch failed").
+- R5. Non-retryable errors are: Firebase `HttpsError` with status 400, 401, 403, 404, or any status outside 429/5xx; any other `Error` not matching the network pattern.
+
+**Streaming Behavior**
+- R6. For `streamCompletion()`, retry is attempted only on fetch-level failures (connection refused, 429, 5xx returned before the stream starts). Once `fetch()` resolves with a 200 Response, the stream is considered live.
+- R7. Mid-stream failures (drop during data consumption) are not retried; the error propagates to the client as-is.
+
+**Configuration**
+- R8. The provider chain order is a static constant in `config.ts`: `["gemini", "zai"]`. Changing the order requires a deploy.
+- R9. The config secret (`JAPANESE_ALCHEMY_CONFIG`) format is unchanged — it still carries `gemini` and `zai` provider configs. The chain reads providers via the existing `createLlmService(name)` path.
+
+**Observability**
+- R10. Each provider attempt (success or failure) is logged via `functions.logger` with the provider name and status. On fallback success, log which provider ultimately served the request.
+- R11. The existing `logLlmUsageTelemetry()` call in handlers is unchanged — it logs the first provider attempted. No new response fields are added.
+
+**Compatibility**
+- R12. `createLlmService("gemini")` or `createLlmService("zai")` with an explicit provider continues to return that single provider (no retry chain).
+- R13. `createLlmService()` with no argument returns the `LlmServiceChain` (uses the full chain).
+
+### Key Decisions
+
+- **Static chain in code, not secret** — Chain order is a constant (`["gemini", "zai"]`) in `config.ts`. Changing it requires a deploy. This avoids config parsing complexity in cold-start functions and keeps the secret schema unchanged. `(session-settled: user-directed — chosen over dynamic secret config: simpler cold-start, no config schema migration)`
+- **Batch + streaming fallback** — Both `chatCompletion` and `streamCompletion` use the same retry-on-429-or-5xx logic. `(session-settled: user-directed — chosen over batch-only: coverage parity, the service interface is shared)`
+- **Streaming: fetch-level only** — Mid-stream drops are not retried. `(session-settled: user-directed — chosen over stream-replay: avoids connection replay complexity; client sees the failure)`
+- **Only 429 and 5xx are retryable** — 400, 401, 403, and other errors propagate immediately. `(session-settled: user-directed — chosen over broader retry: retrying on 400/401/403 wastes the next provider's quota)`
+- **Logging only, no telemetry changes** — Provider chain attempts are logged; the existing `logLlmUsageTelemetry()` stays unchanged. `(session-settled: user-approved — telemetry can be enhanced in a follow-up if needed)`
+
+### Scope Boundaries
+
+- Out of scope: Adding new providers beyond the current two. The chain is `["gemini", "zai"]`; adding providers requires a deploy to update the constant.
+- Out of scope: Config secret format changes. Both providers' credentials remain in the existing `JAPANESE_ALCHEMY_CONFIG` JSON secret.
+- Out of scope: Streaming mid-stream replay. If a stream drops after it has started, the error propagates to the client.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **KTD1. `LlmServiceChain` as a wrapper class.** A new class implementing `LlmService` that holds an array of `LlmService` instances (one per chain member) and iterates them on retryable errors. Not a higher-order function — a class keeps the pattern consistent with existing service classes and makes it easy to extend (e.g., add circuit-breaking later).
+  - **Rationale:** The existing `GeminiLlmService` and `ZaiLlmService` are classes. A wrapper class follows the same pattern, and the factory can return either a single provider or the chain without changing the `LlmService` interface contract.
+  - **Alternative:** A higher-order function that wraps a single `LlmService`. Rejected because it would require handlers to change their call sites to compose the wrapper explicitly.
+
+- **KTD2. `NetworkError` sentinel for fetch network failures.** `fetch()` rejects with `TypeError` (or a plain `Error`) on network failures. A `NetworkError` wrapper class (simple `extends Error`) normalizes these so `shouldRetry()` can match reliably.
+  - **Rationale:** `fetch()` rejection types vary by environment (Node.js `UND_ERR_SOCKET`, browser `TypeError`). Wrapping ensures consistent matching.
+  - **Alternative:** String-matching on `error.message`. Rejected because error messages are implementation-dependent and fragile; a `NetworkError` class is explicit.
+
+- **KTD3. Factory return type change.** `createLlmService()` without arguments returns `LlmServiceChain`. With an explicit `ai` argument, it returns the single provider.
+  - **Rationale:** This is a non-breaking change — all existing calls with explicit `"gemini"` continue to work. Calls without an argument (none currently exist in the codebase) will now get the chain, which is the desired default.
+  - **Alternative:** A separate `createRetryableLlmService()` function. Rejected because it would require handler changes; the factory is the established entry point.
+
+### Assumptions
+
+- Both Gemini and ZAI use the OpenAI-compatible `/chat/completions` protocol (verified in code). The retry wrapper does not need provider-specific logic.
+- Gemini's `thinking_config` extra body is handled per-provider, not in the chain. Each individual service appends its own provider-specific config.
+- Firebase Functions `HttpsError` instances are caught via `instanceof HttpsError` check. The `status` property maps to HTTP status codes (429, 500, etc.).
+- The rate limiter (`checkRateLimit`) runs before the LLM call and is unaffected by this change. Rate limiting at the Firebase Functions level is orthogonal to LLM provider rate limiting.
+
+---
+
+## Implementation Units
+
+### U1. Add `LLM_CHAIN` constant and type to config
+
+- **Goal:** Define the provider chain order and a TypeScript type alias in `config.ts`.
+- **Files:** `japanese-alchemy-hosting/functions/src/config.ts`
+- **Changes:**
+  - Add `export const LLM_CHAIN = ["gemini", "zai"] as const;`
+  - Add `export type LlmChain = readonly string[];` (type alias for the constant)
+- **Patterns to follow:** Existing `LLM_PROVIDER` constant pattern. Use `as const` for type safety.
+- **Test expectation:** none — pure config constant.
+
+### U2. Create `llmRetryService.ts` with `LlmServiceChain` and `shouldRetry()`
+
+- **Goal:** Implement the retry wrapper class and error classification utility.
+- **Files:** `japanese-alchemy-hosting/functions/src/services/llmRetryService.ts` (new)
+- **Design:**
+  - `shouldRetry(error: unknown): boolean` — checks if an error is retryable per R4/R5
+    - Firebase `HttpsError` with status 429 → `true`
+    - Firebase `HttpsError` with status 500-599 → `true`
+    - Generic `Error` with network-related message → `true`
+    - Everything else → `false`
+  - `LlmServiceChain` class implementing `LlmService`:
+    - Constructor: builds an array of `LlmService` instances by calling `createLlmService(name)` for each name in `LLM_CHAIN`
+    - `chatCompletion(systemPrompt, content)`: iterates providers, catches retryable errors, retries with next provider. Throws the last error if all fail.
+    - `streamCompletion(systemPrompt, content)`: same pattern — catches errors at the fetch level before the Response is returned.
+  - Logging: `functions.logger.info` on successful provider; `functions.logger.warn` on each failed attempt with provider name and error message.
+- **Patterns to follow:** Match existing service class structure (`GeminiLlmService` / `ZaiLlmService`). Use `functions.logger`, not `console.log`.
+- **Test Scenarios:**
+  - **T1. Happy path (first provider succeeds):** `chatCompletion()` calls first provider, receives 200, returns response. Logs success with first provider name.
+  - **T2. Fallback on 429:** First provider returns `HttpsError(429)`. Chain catches it, logs warning, calls second provider, second succeeds. Returns second provider's response. Logs which provider served it.
+  - **T3. Fallback on 5xx:** First provider returns `HttpsError(500)`. Chain retries with second provider, second succeeds. Same logging as T2.
+  - **T4. Non-retryable error propagates:** First provider returns `HttpsError(400)`. Chain does NOT retry — throws immediately. Second provider is never called.
+  - **T5. All providers fail (retryable):** First provider 429 → retry second → second 429 → throws last error.
+  - **T6. Network error triggers retry:** First provider `fetch` throws network error (simulated). Chain retries with second provider.
+  - **T7. Streaming — fetch-level retry:** First provider's `fetch()` throws 429. Chain retries `fetch` with second provider. Second provider's Response is returned.
+  - **T8. Streaming — 200 Response returned, no retry after:** First provider's `fetch()` returns 200 Response. The Response object is returned immediately. (Mid-stream drop is not tested here — that's an integration concern.)
+- **Verification:** Run `npm test` in the functions directory. All new tests in `llmRetryService.test.ts` pass.
+
+### U3. Wire chain into factory and add tests
+
+- **Goal:** Update `createLlmService()` to return the chain by default. Add a test file.
+- **Files:** `japanese-alchemy-hosting/functions/src/services/llmService.ts`
+- **Changes:**
+  - Import `LlmServiceChain` from `./llmRetryService`
+  - Import `LLM_CHAIN` from `../config`
+  - Modify `createLlmService()`:
+    ```
+    if (ai is provided) → return single provider (existing behavior)
+    else → return new LlmServiceChain()
+    ```
+- **Patterns to follow:** Existing factory pattern. Keep the existing `switch` for single-provider dispatch.
+- **Test Scenarios:**
+  - **T9. `createLlmService()` returns `LlmServiceChain`** — no argument → chain instance
+  - **T10. `createLlmService("gemini")` returns single provider** — explicit arg → `GeminiLlmService`
+  - **T11. `createLlmService("zai")` returns single provider** — explicit arg → `ZaiLlmService`
+- **Verification:** Run `npm test`. Existing tests still pass (no behavior change for explicit-provider calls).
+
+---
+
+## Verification Contract
+
+| Command | Applicability | Done Signal |
+|---|---|---|
+| `cd japanese-alchemy-hosting/functions && npm run build` | All units | TypeScript compiles with zero errors |
+| `cd japanese-alchemy-hosting/functions && npm test` | All units | All tests pass, including new `llmRetryService.test.ts` |
+| `cd japanese-alchemy-hosting/functions && npm run lint` | All units | ESLint passes with zero warnings |
+| Manual: trigger `explain()` with a configured provider that returns 429 | U2, U3 | Request succeeds via fallback provider; logs show the chain |
+
+---
+
+## Definition of Done
+
+**Global:**
+- TypeScript compiles with zero errors (Node.js 22 runtime)
+- ESLint passes with zero warnings
+- All existing tests continue to pass (no regression)
+- All new test scenarios listed in U2 (T1-T8) and U3 (T9-T11) are implemented and passing
+- No handler code changes required (U1-U3 cover all integration points)
+
+**Per-unit:**
+- U1: `LLM_CHAIN` constant exported, type alias available, no behavioral change
+- U2: `LlmServiceChain` implements `LlmService` interface, all 8 test scenarios pass, error classification matches R4/R5 exactly
+- U3: Factory returns chain by default, single-provider calls unchanged, all 3 test scenarios pass

--- a/docs/plans/2026-09-07-2314-bedrock-llm-provider-plan.md
+++ b/docs/plans/2026-09-07-2314-bedrock-llm-provider-plan.md
@@ -1,0 +1,308 @@
+---
+title: AWS Bedrock LLM Provider
+date: 2026-09-07
+type: plan
+artifact_contract: ce-unified-plan/v1
+artifact_readiness: implementation-ready
+execution: code
+product_contract_source: ce-brainstorm
+---
+
+## Goal Capsule
+
+**Objective:** Add two AWS Bedrock LLM service variants to J-Buddy — one for the `/openai/v1/responses` endpoint (different API shape, adapter required) and one for the `/openai/v1/chat/completions` endpoint (same shape as existing providers) — both production-ready with streaming support, logging, and telemetry.
+
+**Means:** New `BedrockPayloadAdapter` for Bedrock responses format translation, new `BedrockResponsesService` and `BedrockChatService` classes, config schema update, LLM_CHAIN extension to `["bedrock-response", "bedrock-chat", "gemini", "zai"]`, and `createLlmService` updates.
+
+**Stop when:** TypeScript compiles, all new tests pass, existing tests unchanged.
+
+---
+
+## Product Contract
+
+### Problem Frame
+
+J-Buddy currently uses three LLM providers (gemini, zai) via the OpenAI-compatible `/chat/completions` endpoint. AWS Bedrock offers two different OpenAI-compatible endpoints: `/openai/v1/responses` (newer, different API shape) and `/openai/v1/chat/completions` (same shape as existing providers). The gemma model via Bedrock mantle requires the responses endpoint. Both endpoints should be supported with fallback between them, and both should fall back to gemini/zai if Bedrock fails.
+
+### Requirements
+
+**Bedrock Payload Adapter**
+- R1. Create `BedrockPayloadAdapter` (utility object) that translates between J-Buddy's `LlmRequest` shape and Bedrock `/openai/v1/responses` format.
+- R2. `adapter.toBedrockRequest(systemPrompt, content) → Bedrock request body` — maps system prompt to `instructions`, user content to `input: [{type: "input_text", text}]`.
+- R3. `adapter.toLlmResponse(body) → J-Buddy SuccessResponse` — maps Bedrock `output` array to `choices[0].message.content`, extracts text from content blocks, maps `usage.input_tokens` → `prompt_tokens`, `usage.output_tokens` → `completion_tokens`.
+- R4. `adapter.toLlmResponseError(body)` → HttpsError — maps Bedrock error responses to appropriate HttpsError codes.
+
+**Bedrock Responses Service**
+- R5. Create `BedrockResponsesService` implementing `LlmService`, using the `BedrockPayloadAdapter` for request/response translation.
+- R6. Endpoint: `<api_url>/openai/v1/responses`.
+- R7. Config: `{ api_url, api_key, model }` under `config.bedrock.responses`.
+- R8. Streaming: parse Bedrock responses SSE format (event type `content_block_delta` with `delta.type`/`delta.text`, `delta.stop_reason`) and forward as standard SSE chunks through the `Response` object.
+
+**Bedrock Chat Service**
+- R9. Create `BedrockChatService` implementing `LlmService`, using the standard OpenAI `/chat/completions` payload format (same as GeminiLlmService/ZaiLlmService).
+- R10. Endpoint: `<api_url>/openai/v1/chat/completions`.
+- R11. Config: `{ api_url, api_key, model }` under `config.bedrock.chat`.
+- R12. Streaming: same `fetch → Response` pattern as GeminiLlmService (standard SSE).
+
+**Config & Chain**
+- R13. Config schema: add `bedrock` object to `AppConfig` with `responses` and `chat` sub-objects.
+- R14. LLM_CHAIN becomes `["bedrock-response", "bedrock-chat", "gemini", "zai"]`.
+- R15. Provider model is configurable per environment via the config JSON (no hardcoded model in service classes).
+
+**Factory Integration**
+- R16. `createLlmService("bedrock-response")` → `BedrockResponsesService`.
+- R17. `createLlmService("bedrock-chat")` → `BedrockChatService`.
+- R18. `createLlmService()` (no arg) → `LlmServiceChain` (unchanged behavior).
+
+**Observability & Errors**
+- R19. Both services log provider name and model before each call.
+- R20. Error mapping: Bedrock HTTP errors are mapped to appropriate `HttpsError` codes (400 → "invalid-argument", 401/403 → "unauthenticated", 429 → "resource-exhausted", 5xx → "internal").
+- R21. Usage telemetry maps Bedrock `input_tokens`/`output_tokens` to J-Buddy's `prompt_tokens`/`completion_tokens`.
+
+### Scope Boundaries
+
+- Out of scope: Tool/function calling support in Bedrock responses (the gemma model on Bedrock may support tools, but J-Buddy's current analysis prompt does not use tools).
+- Out of scope: Bedrock IAM credential support. The service uses API key auth only (same as existing providers). IAM auth can be added later as a separate concern.
+- Out of scope: Modifying existing `GeminiLlmService` or `ZaiLlmService` behavior. They remain unchanged.
+
+### Key Decisions
+
+- **Two Bedrock variants, not one** — Separate services for responses vs chat/completions endpoints, each with its own adapter/payload shape. `(session-settled: user-directed — chosen over single provider: both endpoints needed, different API shapes require different implementations)`
+- **Adapter for responses, direct for chat** — `BedrockPayloadAdapter` handles the format translation for the responses endpoint; the chat service uses the standard OpenAI payload directly (no adapter needed). `(session-settled: user-directed — chosen over generic adapter: keeps chat service clean, adapter only where needed)`
+- **Chain order: bedrock → bedrock → gemini → zai** — Bedrock variants tried first (lower cost), then gemini, then zai. `(session-settled: user-directed — chosen over gemini-first: bedrock typically lower cost)`
+- **Config schema: `bedrock.responses` + `bedrock.chat`** — Both variants share `api_url` and `api_key` but have independent `model` settings. `(session-settled: user-directed — chosen over separate top-level keys: logical grouping, shared credentials)`
+
+### Success Criteria
+
+- TypeScript compiles without errors
+- All new unit tests pass
+- All existing tests continue to pass
+- `LLM_CHAIN` includes both Bedrock variants in correct order
+- Streaming support works for both Bedrock variants
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- **Two Bedrock variants, not one** - Separate services for responses vs chat/completions endpoints, each with its own adapter/payload shape. Rationale: Different API shapes require different implementations; the gemma model on Bedrock requires the responses endpoint while other providers use chat/completions. `(session-settled: user-directed — chosen over single provider: both endpoints needed, different API shapes require different implementations)`
+- **Adapter for responses, direct for chat** - `BedrockPayloadAdapter` handles the format translation for the responses endpoint; the chat service uses the standard OpenAI payload directly (no adapter needed). Rationale: Keeps chat service clean and minimal; adapter only where needed.
+- **Chain order: bedrock → bedrock → gemini → zai** - Bedrock variants tried first (lower cost), then gemini, then zai. Rationale: Cost optimization based on typical pricing tiers. `(session-settled: user-directed — chosen over gemini-first: bedrock typically lower cost)`
+- **Config schema: `bedrock.responses` + `bedrock.chat`** - Both variants share `api_url` and `api_key` but have independent `model` settings. Rationale: Logical grouping, shared credentials, independent model selection.
+- **No tool calling support** - Out of scope because current analysis prompt doesn't use tools. Can be added later as a separate concern.
+- **API key auth only** - IAM auth not implemented. Can be added later as a separate concern.
+
+### Approach
+
+The implementation follows the existing LLM service abstraction pattern:
+
+1. **Create `BedrockPayloadAdapter`** - Utility class that translates between J-Buddy's `LlmRequest` shape and Bedrock `/openai/v1/responses` format. Maps system prompt to `instructions`, user content to `input: [{type: "input_text", text}]`, and converts Bedrock response content blocks to J-Buddy's `choices[0].message.content`.
+
+2. **Create `BedrockResponsesService`** - Implements `LlmService` interface, uses `BedrockPayloadAdapter`, calls `/openai/v1/responses` endpoint. Streaming parses Bedrock SSE format (event type `content_block_delta` with `delta.type`/`delta.text`, `delta.stop_reason`) and forwards as standard SSE chunks.
+
+3. **Create `BedrockChatService`** - Implements `LlmService` interface, uses standard OpenAI `/chat/completions` payload format (same as `GeminiLlmService`/`ZaiLlmService`). Streaming follows the same `fetch → Response` pattern as existing services.
+
+4. **Update `createLlmService` factory** - Add cases for `"bedrock-response"` and `"bedrock-chat"` providers. Update `LLM_CHAIN` to include both Bedrock variants first.
+
+5. **Update config schema** - Add `bedrock` object to `AppConfig` with `responses` and `chat` sub-objects, each with `api_url`, `api_key`, `model` fields.
+
+### Assumptions
+
+- Bedrock API key authentication works the same way as Gemini/ZAI (Bearer token in Authorization header)
+- Bedrock responses SSE format follows standard SSE conventions (event type `data` with JSON payload)
+- Bedrock error responses follow standard HTTP error patterns with JSON body
+- No rate limiting or quota management beyond what exists in the retry chain
+- The gemma model via Bedrock uses the responses endpoint; other models use chat/completions
+
+### Open Questions
+
+- None — all technical decisions were settled during requirements definition.
+
+---
+
+## Implementation Units
+
+### U1: Create BedrockPayloadAdapter
+
+**Files:** `japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts`
+
+**Dependencies:** None
+
+**Implementation:**
+- Implement `toBedrockRequest(systemPrompt: string, content: string)` - maps system prompt to `instructions`, user content to `input: [{type: "input_text", text}]`
+- Implement `toLlmResponse(body: BedrockResponse) → SuccessResponse` - extracts text from content blocks, maps usage
+- Implement `toLlmResponseError(body: BedrockErrorResponse) → HttpsError` - maps HTTP errors to appropriate codes
+
+**Test scenarios:**
+- Maps system prompt to `instructions` field correctly
+- Maps user content to `input: [{type: "input_text", text}]` format
+- Extracts text from Bedrock content blocks array
+- Maps `usage.input_tokens` → `prompt_tokens`, `usage.output_tokens` → `completion_tokens`
+- Maps 400 → "invalid-argument", 401/403 → "unauthenticated", 429 → "resource-exhausted", 5xx → "internal"
+
+**Verification:** Unit tests in `test/services/bedrockPayloadAdapter.test.ts` pass
+
+---
+
+### U2: Create BedrockResponsesService
+
+**Files:** `japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts`
+
+**Dependencies:** U1 (BedrockPayloadAdapter)
+
+**Implementation:**
+- Implements `LlmService` interface with `chatCompletion()` and `streamCompletion()` methods
+- Uses `BedrockPayloadAdapter` for request/response translation
+- Calls `<api_url>/openai/v1/responses` endpoint
+- Streaming parses Bedrock SSE format (event type `content_block_delta` with `delta.type`/`delta.text`, `delta.stop_reason`)
+- Logs provider name and model before each call
+- Error mapping: Bedrock HTTP errors mapped to appropriate `HttpsError` codes
+
+**Test scenarios:**
+- Happy path: `chatCompletion()` returns valid `SuccessResponse` with usage
+- Happy path: `streamCompletion()` returns valid `Response` object
+- Edge case: Empty content blocks array handled gracefully
+- Error path: 429 triggers retry in chain
+- Error path: 400/401/403 propagate immediately (non-retryable)
+
+**Verification:** Unit tests in `test/services/bedrockResponsesService.test.ts` pass
+
+---
+
+### U3: Create BedrockChatService
+
+**Files:** `japanese-alchemy-hosting/functions/src/services/bedrockChatService.ts`
+
+**Dependencies:** None (uses standard OpenAI payload format)
+
+**Implementation:**
+- Implements `LlmService` interface with `chatCompletion()` and `streamCompletion()` methods
+- Uses standard OpenAI `/chat/completions` payload format (same as `GeminiLlmService`/`ZaiLlmService`)
+- Calls `<api_url>/openai/v1/chat/completions` endpoint
+- Streaming follows same pattern as `GeminiLlmService` (standard SSE)
+- Logs provider name and model before each call
+- Error mapping: Bedrock HTTP errors mapped to appropriate `HttpsError` codes
+
+**Test scenarios:**
+- Happy path: `chatCompletion()` returns valid `SuccessResponse` with usage
+- Happy path: `streamCompletion()` returns valid `Response` object
+- Edge case: Empty choices array handled gracefully
+- Error path: 429 triggers retry in chain
+- Error path: 400/401/403 propagate immediately (non-retryable)
+
+**Verification:** Unit tests in `test/services/bedrockChatService.test.ts` pass
+
+---
+
+### U4: Update createLlmService factory
+
+**Files:** `japanese-alchemy-hosting/functions/src/services/llmService.ts`
+
+**Dependencies:** U2, U3 (BedrockResponsesService, BedrockChatService)
+
+**Implementation:**
+- Add `import { BedrockResponsesService } from "./bedrockResponsesService";`
+- Add `import { BedrockChatService } from "./bedrockChatService";`
+- Update `createLlmService()` switch to handle `"bedrock-response"` and `"bedrock-chat"`
+
+**Test scenarios:**
+- `createLlmService("bedrock-response")` returns `BedrockResponsesService` instance
+- `createLlmService("bedrock-chat")` returns `BedrockChatService` instance
+- `createLlmService()` (no arg) returns `LlmServiceChain` unchanged
+
+**Verification:** Existing unit tests in `test/services/llmService.test.ts` pass
+
+---
+
+### U5: Update config schema and LLM_CHAIN
+
+**Files:** `japanese-alchemy-hosting/functions/src/config.ts`
+
+**Dependencies:** None (config-only change)
+
+**Implementation:**
+- Add `bedrock` interface to `AppConfig` with `responses` and `chat` sub-objects
+- Update `LLM_CHAIN` to `["bedrock-response", "bedrock-chat", "gemini", "zai"]`
+- Update `LLM_PROVIDER` documentation to include new valid values
+
+**Test scenarios:**
+- TypeScript compiles without errors
+- Config validation accepts `bedrock.responses` and `bedrock.chat` structure
+- `LLM_CHAIN` contains all four providers in correct order
+
+**Verification:** TypeScript compilation succeeds, existing unit tests pass
+
+---
+
+## Verification Contract
+
+**Build:** `cd japanese-alchemy-hosting/functions && npm run build`
+**Tests:** `cd japanese-alchemy-hosting/functions && npm test`
+**Lint:** `cd japanese-alchemy-hosting/functions && npm run lint`
+
+**Test files to create:**
+- `japanese-alchemy-hosting/functions/test/services/bedrockPayloadAdapter.test.ts`
+- `japanese-alchemy-hosting/functions/test/services/bedrockResponsesService.test.ts`
+- `japanese-alchemy-hosting/functions/test/services/bedrockChatService.test.ts`
+
+**Test expectations:**
+- U1: PayloadAdapter tests cover all mapping scenarios (R1-R4)
+- U2: BedrockResponsesService tests cover streaming and batch (R5-R8)
+- U3: BedrockChatService tests cover streaming and batch (R9-R12)
+- U4: Factory tests verify new providers (R16-R18)
+- U5: Config tests verify chain order (R14-R15)
+
+---
+
+## Definition of Done
+
+- [ ] All new unit tests pass
+- [ ] Existing tests unchanged (all pass)
+- [ ] TypeScript compiles without errors
+- [ ] ESLint passes without new errors
+- [ ] `LLM_CHAIN` includes both Bedrock variants in correct order
+- [ ] Config schema accepts `bedrock.responses` and `bedrock.chat` configuration
+- [ ] `createLlmService()` factory returns correct service for each provider
+- [ ] Streaming support works for both Bedrock variants
+- [ ] Error mapping returns appropriate `HttpsError` codes
+- [ ] Observability logging includes provider name and model
+
+---
+
+## Appendix
+
+### Existing Patterns to Follow
+
+**GeminiLlmService** (`japanese-alchemy-hosting/functions/src/services/geminiLlmService.ts`)
+- Standard OpenAI-compatible `/chat/completions` implementation
+- Streaming with SSE parsing
+- Error handling and logging patterns
+
+**ZaiLlmService** (`japanese-alchemy-hosting/functions/src/services/zaiLlmService.ts`)
+- Standard OpenAI-compatible `/chat/completions` implementation
+- Streaming with SSE parsing
+- Error handling and logging patterns
+
+**LlmRetryService** (`japanese-alchemy-hosting/functions/src/services/llmRetryService.ts`)
+- Retry chain implementation
+- `shouldRetry()` function for retryable error classification
+- Sequential provider fallback logic
+
+### Bedrock API References
+
+**Bedrock `/openai/v1/responses` endpoint:**
+- Request format: `instructions` array + `input` array with `type: "input_text"`
+- Response format: `output` array with `type: "content_block"` containing `text` field
+- Streaming format: SSE with `content_block_delta` event type
+
+**Bedrock `/openai/v1/chat/completions` endpoint:**
+- Same payload format as existing providers (messages, model, temperature, max_tokens, stream)
+- Standard OpenAI-compatible response format
+- Streaming follows standard SSE pattern
+
+### Out of Scope (per requirements)
+
+- Tool/function calling support in Bedrock responses
+- Bedrock IAM credential support (API key only)
+- Modifying existing `GeminiLlmService` or `ZaiLlmService` behavior

--- a/japanese-alchemy-hosting/.gitignore
+++ b/japanese-alchemy-hosting/.gitignore
@@ -72,8 +72,7 @@ node_modules/
 .env.*
 !.env.example
 !.env.*.example
-functions/.secret.local
-functions/.secret.cloud
+functions/.secret.*
 
 # Keep a shareable Functions secrets template, if added later.
 !functions/secrets.example

--- a/japanese-alchemy-hosting/functions/README.md
+++ b/japanese-alchemy-hosting/functions/README.md
@@ -76,13 +76,13 @@ echo '{"gemini":{"api_url":"https://...","api_key":"...","model":"..."},"zai":{"
   firebase functions:secrets:set JAPANESE_ALCHEMY_CONFIG --data-file=-
 
 # or
-firebase functions:secrets:set JAPANESE_ALCHEMY_CONFIG --data-file=./functions/.secret.local
+firebase functions:secrets:set JAPANESE_ALCHEMY_CONFIG --data-file=./.secret.cloud.json
 ```
 
 After updating, redeploy for functions to pick up the new version:
 
 ```bash
-cd japanese-alchemy-hosting && firebase deploy --only functions
+firebase deploy --only functions
 ```
 
 ## Installation

--- a/japanese-alchemy-hosting/functions/secrets.example
+++ b/japanese-alchemy-hosting/functions/secrets.example
@@ -1,4 +1,14 @@
 JAPANESE_ALCHEMY_CONFIG='{
+  "bedrock_response": {
+    "api_url": "https://bedrock-mantle.us-east-1.api.aws",
+    "api_key": "key",
+    "model": "google.gemma-4-31b"
+  },
+  "bedrock_chat": {
+    "api_url": "https://bedrock-mantle.us-east-1.api.aws",
+    "api_key": "key",
+    "model": "minimax.minimax-m2.5"
+  },
   "gemini": {
     "api_url": "https://generativelanguage.googleapis.com/v1beta/openai",
     "api_key": "key",

--- a/japanese-alchemy-hosting/functions/src/config.ts
+++ b/japanese-alchemy-hosting/functions/src/config.ts
@@ -4,8 +4,10 @@ import { defineJsonSecret } from "firebase-functions/params";
 export const configSecret = defineJsonSecret("JAPANESE_ALCHEMY_CONFIG");
 
 // LLM provider selection — change this to switch providers.
-// Valid values: "gemini" | "zai"
+// Valid values: "gemini" | "zai" | "bedrock-response" | "bedrock-chat"
 export const LLM_PROVIDER: string = "gemini";
+// Static provider chain for sequential fallback (first available wins).
+export const LLM_CHAIN = ["bedrock-response", "bedrock-chat", "gemini", "zai"] as const;
 
 export interface ProviderConfig {
   api_url: string;
@@ -16,6 +18,10 @@ export interface ProviderConfig {
 export interface AppConfig {
   gemini: ProviderConfig;
   zai: ProviderConfig;
+  bedrock: {
+    responses: ProviderConfig;
+    chat: ProviderConfig;
+  };
 }
 
 export function getConfig(): AppConfig {

--- a/japanese-alchemy-hosting/functions/src/config.ts
+++ b/japanese-alchemy-hosting/functions/src/config.ts
@@ -1,13 +1,13 @@
 import { defineJsonSecret } from "firebase-functions/params";
 
-// Define the JSON secret
-export const configSecret = defineJsonSecret("JAPANESE_ALCHEMY_CONFIG");
+const configSecret = defineJsonSecret("JAPANESE_ALCHEMY_CONFIG");
+export const runtimeSecrets = [configSecret];
 
 // LLM provider selection — change this to switch providers.
-// Valid values: "gemini" | "zai" | "bedrock-response" | "bedrock-chat"
+// Valid values: "gemini" | "zai" | "bedrock_response" | "bedrock_chat"
 export const LLM_PROVIDER: string = "gemini";
 // Static provider chain for sequential fallback (first available wins).
-export const LLM_CHAIN = ["bedrock-response", "bedrock-chat", "gemini", "zai"] as const;
+export const LLM_CHAIN = ["bedrock_response", "bedrock_chat", "gemini", "zai"] as const;
 
 export interface ProviderConfig {
   api_url: string;
@@ -18,10 +18,8 @@ export interface ProviderConfig {
 export interface AppConfig {
   gemini: ProviderConfig;
   zai: ProviderConfig;
-  bedrock: {
-    responses: ProviderConfig;
-    chat: ProviderConfig;
-  };
+  bedrock_response: ProviderConfig;
+  bedrock_chat: ProviderConfig;
 }
 
 export function getConfig(): AppConfig {

--- a/japanese-alchemy-hosting/functions/src/index.ts
+++ b/japanese-alchemy-hosting/functions/src/index.ts
@@ -8,25 +8,25 @@ admin.initializeApp();
 import { explainHandler } from "./v1/explainCallable";
 import { explainStreamCallableHandler } from "./v1/explainStreamCallableHandler";
 import { saveItemsHandler } from "./v1/saveItemsCallable";
-import { configSecret } from "./config";
+import { runtimeSecrets } from "./config";
 import { explainRuntimeOptions } from "./runtimeOptions";
 
 // Create and export callable functions with v2 API
-// The configSecret object is passed to the secrets parameter.
+// runtimeSecrets binds the JSON configuration secret to each callable.
 // LLM-backed callables share cost-ceiling runtime options (see
 // runtimeOptions.ts); saveItems is auth-gated and not LLM-backed, so it is
 // left on defaults.
 export const explain = onCall(
-  { ...explainRuntimeOptions, secrets: [configSecret] },
+  { ...explainRuntimeOptions, secrets: runtimeSecrets },
   explainHandler
 );
 
 export const explainStreamCallable = onCall(
-  { ...explainRuntimeOptions, timeoutSeconds: 120, secrets: [configSecret] },
+  { ...explainRuntimeOptions, timeoutSeconds: 120, secrets: runtimeSecrets },
   explainStreamCallableHandler
 );
 
 export const saveItems = onCall(
-  { secrets: [configSecret] },
+  { secrets: runtimeSecrets },
   saveItemsHandler
 );

--- a/japanese-alchemy-hosting/functions/src/models/types.ts
+++ b/japanese-alchemy-hosting/functions/src/models/types.ts
@@ -27,7 +27,7 @@ export interface GrammarItem {
 }
 
 // API request types
-export type AiProvider = "gemini" | "zai" | "bedrock-response" | "bedrock-chat";
+export type AiProvider = "gemini" | "zai" | "bedrock_response" | "bedrock_chat";
 
 export interface ExplainRequest {
   content: string;

--- a/japanese-alchemy-hosting/functions/src/models/types.ts
+++ b/japanese-alchemy-hosting/functions/src/models/types.ts
@@ -27,7 +27,7 @@ export interface GrammarItem {
 }
 
 // API request types
-export type AiProvider = "gemini" | "zai";
+export type AiProvider = "gemini" | "zai" | "bedrock-response" | "bedrock-chat";
 
 export interface ExplainRequest {
   content: string;

--- a/japanese-alchemy-hosting/functions/src/services/bedrockChatService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockChatService.ts
@@ -1,0 +1,135 @@
+import * as functions from "firebase-functions";
+import { LlmRequest, LlmResponse, SuccessResponse } from "../models/types";
+import { configSecret } from "../config";
+import {
+  LlmBatchCompletion,
+  LlmService,
+  LlmStreamCompletion,
+} from "./llmService";
+
+export class BedrockChatService implements LlmService {
+  private apiUrl: string;
+  private apiKey: string;
+  private model: string;
+
+  constructor() {
+    const config = configSecret.value();
+    this.apiUrl = config.bedrock?.chat?.api_url;
+    this.apiKey = config.bedrock?.chat?.api_key;
+    this.model = config.bedrock?.chat?.model;
+
+    if (!this.apiKey) {
+      throw new Error(
+        "Bedrock chat API key not found in JAPANESE_ALCHEMY_CONFIG secret"
+      );
+    }
+  }
+
+  async streamCompletion(
+    systemPrompt: string,
+    content: string
+  ): Promise<LlmStreamCompletion> {
+    const messages = [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: content },
+    ];
+
+    const payload: LlmRequest = {
+      messages,
+      model: this.model,
+      temperature: 0.1,
+      max_tokens: 8192,
+      stream: true,
+    };
+
+    functions.logger.info("Calling Bedrock Chat API (streaming)", {
+      model: this.model,
+      messagesCount: messages.length,
+    });
+
+    const response = await fetch(`${this.apiUrl}/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      functions.logger.error("Bedrock Chat API Error (streaming)", {
+        status: response.status,
+        statusText: response.statusText,
+        error: errorText,
+      });
+      throw new functions.https.HttpsError(
+        "internal",
+        `Bedrock Chat API error: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return { response, requestedModel: this.model };
+  }
+
+  async chatCompletion(
+    systemPrompt: string,
+    content: string
+  ): Promise<LlmBatchCompletion> {
+    const messages = [
+      { role: "system", content: systemPrompt },
+      { role: "user", content: content },
+    ];
+
+    const payload: LlmRequest = {
+      messages,
+      model: this.model,
+      temperature: 0.1,
+      max_tokens: 8192,
+    };
+
+    functions.logger.info("Calling Bedrock Chat API", {
+      model: this.model,
+      messagesCount: messages.length,
+    });
+
+    const response = await fetch(`${this.apiUrl}/openai/v1/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      functions.logger.error("Bedrock Chat API Error", {
+        status: response.status,
+        statusText: response.statusText,
+        error: errorText,
+      });
+      throw new functions.https.HttpsError(
+        "internal",
+        `Bedrock Chat API error: ${response.status} ${response.statusText}`
+      );
+    }
+
+    functions.logger.info("Bedrock Chat API Success");
+    const data = await response.json() as LlmResponse;
+
+    const result: SuccessResponse = {
+      success: true,
+      data: data.choices[0].message.content,
+      timestamp: Date.now(),
+    };
+
+    return {
+      response: result,
+      requestedModel: this.model,
+      usage: data.usage,
+      responseModel: data.model,
+      finishReason: data.choices[0].finish_reason,
+    };
+  }
+}

--- a/japanese-alchemy-hosting/functions/src/services/bedrockChatService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockChatService.ts
@@ -1,6 +1,6 @@
 import * as functions from "firebase-functions";
 import { LlmRequest, LlmResponse, SuccessResponse } from "../models/types";
-import { configSecret } from "../config";
+import { getConfig } from "../config";
 import {
   LlmBatchCompletion,
   LlmService,
@@ -13,7 +13,7 @@ export class BedrockChatService implements LlmService {
   private model: string;
 
   constructor() {
-    const config = configSecret.value();
+    const config = getConfig();
     this.apiUrl = config.bedrock_chat?.api_url;
     this.apiKey = config.bedrock_chat?.api_key;
     this.model = config.bedrock_chat?.model;

--- a/japanese-alchemy-hosting/functions/src/services/bedrockChatService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockChatService.ts
@@ -14,9 +14,9 @@ export class BedrockChatService implements LlmService {
 
   constructor() {
     const config = configSecret.value();
-    this.apiUrl = config.bedrock?.chat?.api_url;
-    this.apiKey = config.bedrock?.chat?.api_key;
-    this.model = config.bedrock?.chat?.model;
+    this.apiUrl = config.bedrock_chat?.api_url;
+    this.apiKey = config.bedrock_chat?.api_key;
+    this.model = config.bedrock_chat?.model;
 
     if (!this.apiKey) {
       throw new Error(

--- a/japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts
@@ -8,18 +8,13 @@ export class BedrockPayloadAdapter {
   /**
    * Converts J-Buddy's request format to Bedrock /openai/v1/responses format.
    * - system prompt → instructions string
-   * - user content → input: [{type: "input_text", text}]
+   * - user content → input string
    */
   toBedrockRequest(systemPrompt: string, content: string): object {
     return {
       model: "gemma-2-9b-it",
       instructions: systemPrompt,
-      input: [
-        {
-          type: "input_text",
-          text: content,
-        },
-      ],
+      input: content,
       temperature: 0.1,
       max_tokens: 8192,
       stream: false,

--- a/japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts
@@ -7,18 +7,13 @@ import { SuccessResponse } from "../models/types";
 export class BedrockPayloadAdapter {
   /**
    * Converts J-Buddy's request format to Bedrock /openai/v1/responses format.
-   * - system prompt → instructions array
+   * - system prompt → instructions string
    * - user content → input: [{type: "input_text", text}]
    */
   toBedrockRequest(systemPrompt: string, content: string): object {
     return {
       model: "gemma-2-9b-it",
-      instructions: [
-        {
-          type: "input_text",
-          text: systemPrompt,
-        },
-      ],
+      instructions: systemPrompt,
       input: [
         {
           type: "input_text",

--- a/japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts
@@ -1,0 +1,76 @@
+import { SuccessResponse } from "../models/types";
+
+/**
+ * BedrockPayloadAdapter translates between J-Buddy's LlmRequest shape
+ * and Bedrock /openai/v1/responses format.
+ */
+export class BedrockPayloadAdapter {
+  /**
+   * Converts J-Buddy's request format to Bedrock /openai/v1/responses format.
+   * - system prompt → instructions array
+   * - user content → input: [{type: "input_text", text}]
+   */
+  toBedrockRequest(systemPrompt: string, content: string): object {
+    return {
+      model: "gemma-2-9b-it",
+      instructions: [
+        {
+          type: "input_text",
+          text: systemPrompt,
+        },
+      ],
+      input: [
+        {
+          type: "input_text",
+          text: content,
+        },
+      ],
+      temperature: 0.1,
+      max_tokens: 8192,
+      stream: false,
+    };
+  }
+
+  /**
+   * Converts Bedrock response to J-Buddy's SuccessResponse format.
+   * - Extracts text from content blocks
+   * - Maps usage: input_tokens → prompt_tokens, output_tokens → completion_tokens
+   */
+  toLlmResponse(body: any): SuccessResponse {
+    const contentBlocks = body.output?.content || [];
+    const text = contentBlocks
+      .filter((block: any) => block.type === "content_block")
+      .map((block: any) => block.text)
+      .join("");
+
+    return {
+      success: true,
+      data: text,
+      timestamp: Date.now(),
+    };
+  }
+
+  /**
+   * Converts Bedrock error response to HttpsError.
+   * - 400 → "invalid-argument"
+   * - 401/403 → "unauthenticated"
+   * - 429 → "resource-exhausted"
+   * - 5xx → "internal"
+   */
+  toLlmResponseError(status: number): any {
+    switch (status) {
+      case 400:
+        return new Error(`invalid-argument: Bedrock API error`);
+      case 401:
+      case 403:
+        return new Error(`unauthenticated: Bedrock API error`);
+      case 429:
+        return new Error(`resource-exhausted: Bedrock API error`);
+      default:
+        if (status >= 500 && status < 600) {
+          return new Error(`internal: Bedrock API error`);
+        }
+        return new Error(`internal: Bedrock API error`);
+    }
+  }
+}

--- a/japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts
@@ -13,7 +13,8 @@ export class BedrockPayloadAdapter {
   toBedrockRequest(
     model: string,
     systemPrompt: string,
-    content: string
+    content: string,
+    stream = false
   ): object {
     return {
       model,
@@ -21,7 +22,7 @@ export class BedrockPayloadAdapter {
       input: content,
       temperature: 0.1,
       max_tokens: 8192,
-      stream: false,
+      stream,
     };
   }
 

--- a/japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockPayloadAdapter.ts
@@ -10,9 +10,13 @@ export class BedrockPayloadAdapter {
    * - system prompt → instructions string
    * - user content → input string
    */
-  toBedrockRequest(systemPrompt: string, content: string): object {
+  toBedrockRequest(
+    model: string,
+    systemPrompt: string,
+    content: string
+  ): object {
     return {
-      model: "gemma-2-9b-it",
+      model,
       instructions: systemPrompt,
       input: content,
       temperature: 0.1,

--- a/japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts
@@ -1,6 +1,6 @@
 import * as functions from "firebase-functions";
 import { SuccessResponse, LlmUsage } from "../models/types";
-import { configSecret } from "../config";
+import { getConfig } from "../config";
 import {
   LlmBatchCompletion,
   LlmService,
@@ -15,7 +15,7 @@ export class BedrockResponsesService implements LlmService {
   private adapter: BedrockPayloadAdapter;
 
   constructor() {
-    const config = configSecret.value();
+    const config = getConfig();
     this.apiUrl = config.bedrock_response?.api_url;
     this.apiKey = config.bedrock_response?.api_key;
     this.model = config.bedrock_response?.model;

--- a/japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts
@@ -16,9 +16,9 @@ export class BedrockResponsesService implements LlmService {
 
   constructor() {
     const config = configSecret.value();
-    this.apiUrl = config.bedrock?.responses?.api_url;
-    this.apiKey = config.bedrock?.responses?.api_key;
-    this.model = config.bedrock?.responses?.model || "gemma-2-9b-it";
+    this.apiUrl = config.bedrock_response?.api_url;
+    this.apiKey = config.bedrock_response?.api_key;
+    this.model = config.bedrock_response?.model;
     this.adapter = new BedrockPayloadAdapter();
 
     if (!this.apiKey) {

--- a/japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts
@@ -32,7 +32,11 @@ export class BedrockResponsesService implements LlmService {
     systemPrompt: string,
     content: string
   ): Promise<LlmStreamCompletion> {
-    const payload = this.adapter.toBedrockRequest(systemPrompt, content);
+    const payload = this.adapter.toBedrockRequest(
+      this.model,
+      systemPrompt,
+      content
+    );
 
     functions.logger.info("Calling Bedrock Responses API (streaming)", {
       model: this.model,
@@ -69,7 +73,11 @@ export class BedrockResponsesService implements LlmService {
     systemPrompt: string,
     content: string
   ): Promise<LlmBatchCompletion> {
-    const payload = this.adapter.toBedrockRequest(systemPrompt, content);
+    const payload = this.adapter.toBedrockRequest(
+      this.model,
+      systemPrompt,
+      content
+    );
 
     functions.logger.info("Calling Bedrock Responses API", {
       model: this.model,

--- a/japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts
@@ -35,7 +35,8 @@ export class BedrockResponsesService implements LlmService {
     const payload = this.adapter.toBedrockRequest(
       this.model,
       systemPrompt,
-      content
+      content,
+      true
     );
 
     functions.logger.info("Calling Bedrock Responses API (streaming)", {

--- a/japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/bedrockResponsesService.ts
@@ -1,0 +1,123 @@
+import * as functions from "firebase-functions";
+import { SuccessResponse, LlmUsage } from "../models/types";
+import { configSecret } from "../config";
+import {
+  LlmBatchCompletion,
+  LlmService,
+  LlmStreamCompletion,
+} from "./llmService";
+import { BedrockPayloadAdapter } from "./bedrockPayloadAdapter";
+
+export class BedrockResponsesService implements LlmService {
+  private apiUrl: string;
+  private apiKey: string;
+  private model: string;
+  private adapter: BedrockPayloadAdapter;
+
+  constructor() {
+    const config = configSecret.value();
+    this.apiUrl = config.bedrock?.responses?.api_url;
+    this.apiKey = config.bedrock?.responses?.api_key;
+    this.model = config.bedrock?.responses?.model || "gemma-2-9b-it";
+    this.adapter = new BedrockPayloadAdapter();
+
+    if (!this.apiKey) {
+      throw new Error(
+        "Bedrock responses API key not found in JAPANESE_ALCHEMY_CONFIG secret"
+      );
+    }
+  }
+
+  async streamCompletion(
+    systemPrompt: string,
+    content: string
+  ): Promise<LlmStreamCompletion> {
+    const payload = this.adapter.toBedrockRequest(systemPrompt, content);
+
+    functions.logger.info("Calling Bedrock Responses API (streaming)", {
+      model: this.model,
+      systemPromptLength: systemPrompt.length,
+      contentLength: content.length,
+    });
+
+    const response = await fetch(`${this.apiUrl}/openai/v1/responses`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      functions.logger.error("Bedrock Responses API Error (streaming)", {
+        status: response.status,
+        statusText: response.statusText,
+        error: errorText,
+      });
+      throw new functions.https.HttpsError(
+        "internal",
+        `Bedrock Responses API error: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return { response, requestedModel: this.model };
+  }
+
+  async chatCompletion(
+    systemPrompt: string,
+    content: string
+  ): Promise<LlmBatchCompletion> {
+    const payload = this.adapter.toBedrockRequest(systemPrompt, content);
+
+    functions.logger.info("Calling Bedrock Responses API", {
+      model: this.model,
+      systemPromptLength: systemPrompt.length,
+      contentLength: content.length,
+    });
+
+    const response = await fetch(`${this.apiUrl}/openai/v1/responses`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      functions.logger.error("Bedrock Responses API Error", {
+        status: response.status,
+        statusText: response.statusText,
+        error: errorText,
+      });
+      throw new functions.https.HttpsError(
+        "internal",
+        `Bedrock Responses API error: ${response.status} ${response.statusText}`
+      );
+    }
+
+    functions.logger.info("Bedrock Responses API Success");
+    const data: any = await response.json();
+
+    const result: SuccessResponse = this.adapter.toLlmResponse(data);
+
+    const usage: LlmUsage | undefined = data.usage
+      ? {
+          prompt_tokens: data.usage.input_tokens,
+          completion_tokens: data.usage.output_tokens,
+          total_tokens: data.usage.total_tokens,
+        }
+      : undefined;
+
+    return {
+      response: result,
+      requestedModel: this.model,
+      usage: usage,
+      responseModel: this.model,
+      finishReason: "stop",
+    };
+  }
+}

--- a/japanese-alchemy-hosting/functions/src/services/geminiLlmService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/geminiLlmService.ts
@@ -1,6 +1,6 @@
 import * as functions from "firebase-functions";
 import { LlmRequest, LlmResponse, SuccessResponse } from "../models/types";
-import { configSecret } from "../config";
+import { getConfig } from "../config";
 import { LlmBatchCompletion, LlmService, LlmStreamCompletion } from "./llmService";
 
 export class GeminiLlmService implements LlmService {
@@ -9,7 +9,7 @@ export class GeminiLlmService implements LlmService {
   private model: string;
 
   constructor() {
-    const config = configSecret.value();
+    const config = getConfig();
     this.apiUrl = config.gemini.api_url;
     this.apiKey = config.gemini.api_key;
     this.model = config.gemini.model;

--- a/japanese-alchemy-hosting/functions/src/services/llmRetryService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/llmRetryService.ts
@@ -1,0 +1,153 @@
+import * as functions from "firebase-functions";
+import { LlmBatchCompletion, LlmService, LlmStreamCompletion, createLlmService } from "./llmService";
+import { LLM_CHAIN } from "../config";
+
+/**
+ * Extracts the numeric HTTP status from a Firebase HttpsError message.
+ * Services format messages as "<name> API error: <code> <text>",
+ * so the last space-separated token is the status number.
+ */
+function extractHttpStatus(error: unknown): number | undefined {
+  if (!(error instanceof functions.https.HttpsError)) {
+    return undefined;
+  }
+  const msg = error.message;
+  const parts = msg.split(":");
+  if (parts.length === 0) return undefined;
+  const lastPart = parts[parts.length - 1].trim();
+  const statusMatch = lastPart.match(/^(\d{3})/);
+  return statusMatch ? parseInt(statusMatch[1], 10) : undefined;
+}
+
+/**
+ * Returns true if the error should trigger a retry with the next provider.
+ *
+ * Retryable:
+ *   - HTTP 429 (rate limit) — extracted from HttpsError message
+ *   - HTTP 5xx (server error) — extracted from HttpsError message
+ *   - Network-level errors (TypeError from fetch, socket errors, etc.)
+ *
+ * Non-retryable:
+ *   - HTTP 4xx (except 429) — bad request, unauthorized, not found, etc.
+ *   - Any other Error not matching the network pattern
+ */
+export function shouldRetry(error: unknown): boolean {
+  // Check for retryable HTTP status from HttpsError message
+  const httpStatus = extractHttpStatus(error);
+  if (httpStatus !== undefined && (httpStatus === 429 || (httpStatus >= 500 && httpStatus <= 599))) {
+    return true;
+  }
+
+  // Check for network-level errors (TypeError from fetch, socket errors, etc.)
+  if (error instanceof TypeError) {
+    return true;
+  }
+
+  if (error instanceof Error) {
+    const msg = error.message.toLowerCase();
+    const networkSignals = [
+      "econnreset",
+      "etimedout",
+      "econnrefused",
+      "enotfound",
+      "fetch failed",
+      "network error",
+      "networkrequestfailed",
+    ];
+    if (networkSignals.some((signal) => msg.includes(signal))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * A chain of LLM providers that retries sequentially on 429/5xx errors.
+ *
+ * Built-in behaviors:
+ * - Iterates through LLM_CHAIN (["gemini", "zai"]) in order
+ * - Retries only on retryable errors (429, 5xx, network failures)
+ * - Propagates non-retryable errors immediately (400, 401, 403, etc.)
+ * - Logs each attempt and the ultimate provider on success
+ * - For streaming: retries only before fetch resolves (R6/R7)
+ */
+export class LlmServiceChain implements LlmService {
+  private providers: LlmService[];
+
+  constructor() {
+    this.providers = LLM_CHAIN.map((name) =>
+      createLlmService(name as "gemini" | "zai")
+    );
+  }
+
+  async chatCompletion(
+    systemPrompt: string,
+    content: string
+  ): Promise<LlmBatchCompletion> {
+    let lastError: Error | undefined;
+
+    for (let i = 0; i < this.providers.length; i++) {
+      const provider = this.providers[i];
+      const providerName = LLM_CHAIN[i];
+
+      try {
+        const result = await provider.chatCompletion(systemPrompt, content);
+        functions.logger.info("LLM chain: batch completed", {
+          provider: providerName,
+        });
+        return result;
+      } catch (error) {
+        if (!shouldRetry(error)) {
+          functions.logger.error(
+            `LLM chain: non-retryable error from ${providerName}`,
+            error
+          );
+          throw error;
+        }
+        lastError = error instanceof Error ? error : new Error(String(error));
+        functions.logger.warn(
+          `LLM chain: ${providerName} failed (${lastError.message}), trying next`
+        );
+      }
+    }
+
+    // All providers failed with retryable errors
+    throw lastError ?? new Error("All LLM providers failed");
+  }
+
+  async streamCompletion(
+    systemPrompt: string,
+    content: string
+  ): Promise<LlmStreamCompletion> {
+    let lastError: Error | undefined;
+
+    for (let i = 0; i < this.providers.length; i++) {
+      const provider = this.providers[i];
+      const providerName = LLM_CHAIN[i];
+
+      try {
+        const result = await provider.streamCompletion(systemPrompt, content);
+        functions.logger.info("LLM chain: stream started", {
+          provider: providerName,
+        });
+        return result;
+      } catch (error) {
+        if (!shouldRetry(error)) {
+          functions.logger.error(
+            `LLM chain: non-retryable error from ${providerName}`,
+            error
+          );
+          throw error;
+        }
+        lastError = error instanceof Error ? error : new Error(String(error));
+        functions.logger.warn(
+          `LLM chain: ${providerName} failed (${lastError.message}), trying next`
+        );
+      }
+    }
+
+    // All providers failed with retryable errors
+    throw lastError ?? new Error("All LLM providers failed");
+  }
+}

--- a/japanese-alchemy-hosting/functions/src/services/llmService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/llmService.ts
@@ -1,7 +1,9 @@
 import { AiProvider, LlmUsage, SuccessResponse } from "../models/types";
-import { LLM_PROVIDER } from "../config";
 import { GeminiLlmService } from "./geminiLlmService";
+import { LlmServiceChain } from "./llmRetryService";
 import { ZaiLlmService } from "./zaiLlmService";
+import { BedrockResponsesService } from "./bedrockResponsesService";
+import { BedrockChatService } from "./bedrockChatService";
 
 export interface LlmService {
   chatCompletion(systemPrompt: string, content: string): Promise<LlmBatchCompletion>;
@@ -22,16 +24,22 @@ export interface LlmStreamCompletion {
 }
 
 /**
- * Factory: creates an LlmService for an explicitly selected AI, or retains the
- * configured provider when no selection is supplied by a caller outside the
- * explain request handlers.
+ * Factory: creates an LlmService for an explicitly selected AI, or a
+ * sequential fallback chain when no selection is supplied.
  */
 export function createLlmService(ai?: AiProvider): LlmService {
-  switch (ai ?? LLM_PROVIDER) {
-    case "zai":
-      return new ZaiLlmService();
-    case "gemini":
-    default:
-      return new GeminiLlmService();
+  if (ai !== undefined) {
+    switch (ai) {
+      case "bedrock-response":
+        return new BedrockResponsesService();
+      case "bedrock-chat":
+        return new BedrockChatService();
+      case "zai":
+        return new ZaiLlmService();
+      case "gemini":
+      default:
+        return new GeminiLlmService();
+    }
   }
+  return new LlmServiceChain();
 }

--- a/japanese-alchemy-hosting/functions/src/services/llmService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/llmService.ts
@@ -30,9 +30,9 @@ export interface LlmStreamCompletion {
 export function createLlmService(ai?: AiProvider): LlmService {
   if (ai !== undefined) {
     switch (ai) {
-      case "bedrock-response":
+      case "bedrock_response":
         return new BedrockResponsesService();
-      case "bedrock-chat":
+      case "bedrock_chat":
         return new BedrockChatService();
       case "zai":
         return new ZaiLlmService();

--- a/japanese-alchemy-hosting/functions/src/services/zaiLlmService.ts
+++ b/japanese-alchemy-hosting/functions/src/services/zaiLlmService.ts
@@ -1,6 +1,6 @@
 import * as functions from "firebase-functions";
 import { LlmRequest, LlmResponse, SuccessResponse } from "../models/types";
-import { configSecret } from "../config";
+import { getConfig } from "../config";
 import { LlmBatchCompletion, LlmService, LlmStreamCompletion } from "./llmService";
 
 export class ZaiLlmService implements LlmService {
@@ -9,7 +9,7 @@ export class ZaiLlmService implements LlmService {
   private model: string;
 
   constructor() {
-    const config = configSecret.value();
+    const config = getConfig();
     this.apiUrl = config.zai.api_url;
     this.apiKey = config.zai.api_key;
     this.model = config.zai.model;

--- a/japanese-alchemy-hosting/functions/src/v1/explainCallable.ts
+++ b/japanese-alchemy-hosting/functions/src/v1/explainCallable.ts
@@ -24,7 +24,7 @@ export async function explainHandler(request: any): Promise<SuccessResponse> {
   }
 
   // Defaults match the Chrome extension and streaming callable.
-  const { content, prompt = "v2", context_before, context_after } = data;
+  const { content, prompt = "v2", context_before, context_after, ai } = data;
 
   // Per-IP rate limit (parity with explainStreamCallable). The callable's client IP is
   // on the underlying Express request.
@@ -45,14 +45,14 @@ export async function explainHandler(request: any): Promise<SuccessResponse> {
   const systemPrompt = prompt === "v2" ? SYSTEM_PROMPT_V2 : SYSTEM_PROMPT_V1;
 
   try {
-    const llmService = createLlmService("gemini");
+    const llmService = createLlmService(ai);
     const completion = await llmService.chatCompletion(
       systemPrompt,
       buildAnalysisMessage(content, { before: context_before, after: context_after })
     );
 
     logLlmUsageTelemetry({
-      provider: "gemini",
+      provider: (ai as any) || "gemini",
       requestedModel: completion.requestedModel,
       responseModel: completion.responseModel,
       operation: "batch",

--- a/japanese-alchemy-hosting/functions/src/v1/explainStreamCallableHandler.ts
+++ b/japanese-alchemy-hosting/functions/src/v1/explainStreamCallableHandler.ts
@@ -60,11 +60,11 @@ export async function explainStreamCallableHandler(
     throw callableErrorForRateLimit(rateLimit.reason);
   }
 
-  const { content, prompt = "v2", context_before, context_after } = request.data as any;
+  const { content, prompt = "v2", context_before, context_after, ai } = request.data as any;
   const systemPrompt = prompt === "v2" ? SYSTEM_PROMPT_V2 : SYSTEM_PROMPT_V1;
 
   try {
-    const llmService = createLlmService("gemini");
+    const llmService = createLlmService(ai);
     const completion = await llmService.streamCompletion(
       systemPrompt,
       buildAnalysisMessage(content, { before: context_before, after: context_after })
@@ -77,7 +77,7 @@ export async function explainStreamCallableHandler(
     });
 
     logLlmUsageTelemetry({
-      provider: "gemini",
+      provider: (ai as any) || "gemini",
       requestedModel: completion.requestedModel,
       responseModel: streamResult.responseModel,
       operation: "stream",

--- a/japanese-alchemy-hosting/functions/src/v1/llmStreamDeltas.ts
+++ b/japanese-alchemy-hosting/functions/src/v1/llmStreamDeltas.ts
@@ -8,8 +8,19 @@ export interface StreamConsumptionResult {
 }
 
 interface StreamEnvelope {
+  type?: string;
+  delta?: string;
   model?: string;
   usage?: LlmUsage;
+  response?: {
+    model?: string;
+    status?: string;
+    usage?: {
+      input_tokens?: number;
+      output_tokens?: number;
+      total_tokens?: number;
+    };
+  };
   choices?: Array<{
     delta?: { content?: string };
     finish_reason?: string | null;
@@ -46,9 +57,25 @@ export async function consumeLlmStream(
       const envelope = JSON.parse(data) as StreamEnvelope;
       if (envelope.usage) latestUsage = envelope.usage;
       if (envelope.model) responseModel = envelope.model;
+      const response = envelope.response;
+      if (response?.model) responseModel = response.model;
+      if (response?.usage) {
+        latestUsage = {
+          prompt_tokens: response.usage.input_tokens,
+          completion_tokens: response.usage.output_tokens,
+          total_tokens: response.usage.total_tokens,
+        };
+      }
       const choice = envelope.choices?.[0];
       if (choice?.finish_reason !== undefined) finishReason = choice.finish_reason;
       if (choice?.delta?.content) await onDelta(choice.delta.content);
+      if (envelope.type === "response.output_text.delta" && envelope.delta) {
+        await onDelta(envelope.delta);
+      }
+      if (envelope.type === "response.completed") {
+        completed = true;
+        finishReason = response?.status === "completed" ? "stop" : response?.status;
+      }
     } catch {
       // Malformed provider frames are ignored; terminal completion remains false.
     }

--- a/japanese-alchemy-hosting/functions/test/config.test.ts
+++ b/japanese-alchemy-hosting/functions/test/config.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
-import { configSecret, getConfig, LLM_PROVIDER } from "../src/config";
+import { getConfig, LLM_PROVIDER, runtimeSecrets } from "../src/config";
 
 // Mock firebase-functions/params so defineJsonSecret returns a config object
-// shaped like the real JAPANESE_ALCHEMY_CONFIG secret: { gemini, zai }.
+// shaped like the real JAPANESE_ALCHEMY_CONFIG secret.
 jest.mock("firebase-functions/params", () => ({
   defineJsonSecret: jest.fn((name: string) => ({
     name,
@@ -17,6 +17,16 @@ jest.mock("firebase-functions/params", () => ({
         api_key: "test-zai-key",
         model: "test-zai-model",
       },
+      bedrock_response: {
+        api_url: "https://bedrock-responses.test-api-url.com",
+        api_key: "test-bedrock-responses-key",
+        model: "test-bedrock-responses-model",
+      },
+      bedrock_chat: {
+        api_url: "https://bedrock-chat.test-api-url.com",
+        api_key: "test-bedrock-chat-key",
+        model: "test-bedrock-chat-model",
+      },
     })),
   })),
 }));
@@ -26,16 +36,18 @@ describe("Configuration", () => {
     jest.clearAllMocks();
   });
 
-  it("should define secret with correct name", () => {
-    expect(configSecret.name).toBe("JAPANESE_ALCHEMY_CONFIG");
+  it("should bind the configuration secret to callable runtime options", () => {
+    expect(runtimeSecrets[0].name).toBe("JAPANESE_ALCHEMY_CONFIG");
   });
 
-  it("should return the gemini and zai provider configs", () => {
+  it("should return all provider configs", () => {
     const config = getConfig();
 
     expect(config).toBeDefined();
     expect(config).toHaveProperty("gemini");
     expect(config).toHaveProperty("zai");
+    expect(config).toHaveProperty("bedrock_response");
+    expect(config).toHaveProperty("bedrock_chat");
   });
 
   it("should return the Gemini provider config", () => {
@@ -52,6 +64,21 @@ describe("Configuration", () => {
     expect(config.zai.api_url).toBe("https://zai.test-api-url.com");
     expect(config.zai.api_key).toBe("test-zai-key");
     expect(config.zai.model).toBe("test-zai-model");
+  });
+
+  it("should return the Bedrock provider configs", () => {
+    const config = getConfig();
+
+    expect(config.bedrock_response).toEqual({
+      api_url: "https://bedrock-responses.test-api-url.com",
+      api_key: "test-bedrock-responses-key",
+      model: "test-bedrock-responses-model",
+    });
+    expect(config.bedrock_chat).toEqual({
+      api_url: "https://bedrock-chat.test-api-url.com",
+      api_key: "test-bedrock-chat-key",
+      model: "test-bedrock-chat-model",
+    });
   });
 
   it("should default the active provider to gemini", () => {

--- a/japanese-alchemy-hosting/functions/test/index.test.ts
+++ b/japanese-alchemy-hosting/functions/test/index.test.ts
@@ -6,7 +6,7 @@ jest.mock("firebase-functions/v2/https", () => ({
   onCall: (...args: unknown[]) => mockOnCall(...args),
   onRequest: (...args: unknown[]) => mockOnRequest(...args),
 }));
-jest.mock("../src/config", () => ({ configSecret: {} }));
+jest.mock("../src/config", () => ({ runtimeSecrets: [] }));
 jest.mock("../src/runtimeOptions", () => ({ explainRuntimeOptions: {} }));
 jest.mock("../src/v1/explainCallable", () => ({ explainHandler: jest.fn() }));
 jest.mock("../src/v1/explainStreamCallableHandler", () => ({

--- a/japanese-alchemy-hosting/functions/test/prompts/promptQuality.test.ts
+++ b/japanese-alchemy-hosting/functions/test/prompts/promptQuality.test.ts
@@ -34,7 +34,6 @@ jest.mock("../../src/config", () => {
   const config = fsp.existsSync(secretsPath) ? JSON.parse(fsp.readFileSync(secretsPath, "utf8")) : {};
   const provider = process.env.PROMPT_PROVIDER || "gemini";
   return {
-    configSecret: { name: "JAPANESE_ALCHEMY_CONFIG", value: () => config },
     LLM_PROVIDER: provider,
     getConfig: () => config,
   };

--- a/japanese-alchemy-hosting/functions/test/services/bedrockPayloadAdapter.test.ts
+++ b/japanese-alchemy-hosting/functions/test/services/bedrockPayloadAdapter.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "@jest/globals";
+import { BedrockPayloadAdapter } from "../../src/services/bedrockPayloadAdapter";
+
+describe("BedrockPayloadAdapter", () => {
+  it("sends the system prompt as the string-valued Responses instructions field", () => {
+    const systemPrompt = "Explain this Japanese text.";
+    const payload = new BedrockPayloadAdapter().toBedrockRequest(
+      systemPrompt,
+      "日本語"
+    ) as { instructions: unknown; input: unknown };
+
+    expect(payload.instructions).toBe(systemPrompt);
+    expect(payload.input).toEqual([
+      { type: "input_text", text: "日本語" },
+    ]);
+  });
+});

--- a/japanese-alchemy-hosting/functions/test/services/bedrockPayloadAdapter.test.ts
+++ b/japanese-alchemy-hosting/functions/test/services/bedrockPayloadAdapter.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "@jest/globals";
 import { BedrockPayloadAdapter } from "../../src/services/bedrockPayloadAdapter";
 
 describe("BedrockPayloadAdapter", () => {
-  it("sends the system prompt as the string-valued Responses instructions field", () => {
+  it("sends string-valued instructions and input accepted by the Responses API", () => {
     const systemPrompt = "Explain this Japanese text.";
     const payload = new BedrockPayloadAdapter().toBedrockRequest(
       systemPrompt,
@@ -10,8 +10,6 @@ describe("BedrockPayloadAdapter", () => {
     ) as { instructions: unknown; input: unknown };
 
     expect(payload.instructions).toBe(systemPrompt);
-    expect(payload.input).toEqual([
-      { type: "input_text", text: "日本語" },
-    ]);
+    expect(payload.input).toBe("日本語");
   });
 });

--- a/japanese-alchemy-hosting/functions/test/services/bedrockPayloadAdapter.test.ts
+++ b/japanese-alchemy-hosting/functions/test/services/bedrockPayloadAdapter.test.ts
@@ -8,11 +8,13 @@ describe("BedrockPayloadAdapter", () => {
     const payload = new BedrockPayloadAdapter().toBedrockRequest(
       model,
       systemPrompt,
-      "日本語"
-    ) as { model: unknown; instructions: unknown; input: unknown };
+      "日本語",
+      true
+    ) as { model: unknown; instructions: unknown; input: unknown; stream: unknown };
 
     expect(payload.model).toBe(model);
     expect(payload.instructions).toBe(systemPrompt);
     expect(payload.input).toBe("日本語");
+    expect(payload.stream).toBe(true);
   });
 });

--- a/japanese-alchemy-hosting/functions/test/services/bedrockPayloadAdapter.test.ts
+++ b/japanese-alchemy-hosting/functions/test/services/bedrockPayloadAdapter.test.ts
@@ -3,12 +3,15 @@ import { BedrockPayloadAdapter } from "../../src/services/bedrockPayloadAdapter"
 
 describe("BedrockPayloadAdapter", () => {
   it("sends string-valued instructions and input accepted by the Responses API", () => {
+    const model = "google.gemma-4-31b";
     const systemPrompt = "Explain this Japanese text.";
     const payload = new BedrockPayloadAdapter().toBedrockRequest(
+      model,
       systemPrompt,
       "日本語"
-    ) as { instructions: unknown; input: unknown };
+    ) as { model: unknown; instructions: unknown; input: unknown };
 
+    expect(payload.model).toBe(model);
     expect(payload.instructions).toBe(systemPrompt);
     expect(payload.input).toBe("日本語");
   });

--- a/japanese-alchemy-hosting/functions/test/services/bedrockResponsesService.test.ts
+++ b/japanese-alchemy-hosting/functions/test/services/bedrockResponsesService.test.ts
@@ -2,15 +2,13 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { BedrockResponsesService } from "../../src/services/bedrockResponsesService";
 
 jest.mock("../../src/config", () => ({
-  configSecret: {
-    value: () => ({
+  getConfig: () => ({
       bedrock_response: {
         api_url: "https://bedrock.example",
         api_key: "test-api-key",
         model: "google.gemma-4-31b",
       },
     }),
-  },
 }));
 
 const mockFetch = jest.fn() as any;

--- a/japanese-alchemy-hosting/functions/test/services/bedrockResponsesService.test.ts
+++ b/japanese-alchemy-hosting/functions/test/services/bedrockResponsesService.test.ts
@@ -1,0 +1,30 @@
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import { BedrockResponsesService } from "../../src/services/bedrockResponsesService";
+
+jest.mock("../../src/config", () => ({
+  configSecret: {
+    value: () => ({
+      bedrock_response: {
+        api_url: "https://bedrock.example",
+        api_key: "test-api-key",
+        model: "google.gemma-4-31b",
+      },
+    }),
+  },
+}));
+
+const mockFetch = jest.fn() as any;
+(global as any).fetch = mockFetch;
+
+describe("BedrockResponsesService", () => {
+  beforeEach(() => mockFetch.mockClear());
+
+  it("requests an SSE response for streamCompletion", async () => {
+    mockFetch.mockResolvedValue({ ok: true });
+
+    await new BedrockResponsesService().streamCompletion("system", "日本語");
+
+    const payload = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(payload.stream).toBe(true);
+  });
+});

--- a/japanese-alchemy-hosting/functions/test/services/geminiLlmService.test.ts
+++ b/japanese-alchemy-hosting/functions/test/services/geminiLlmService.test.ts
@@ -1,22 +1,20 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import { GeminiLlmService } from "../../src/services/geminiLlmService";
 
-// Mock the config so configSecret.value().gemini returns test credentials.
+// Mock the configuration interface with test credentials.
 jest.mock("../../src/config", () => ({
-  configSecret: {
-    value: () => ({
-      gemini: {
-        api_url: "https://test-api-url.com",
-        api_key: "test-api-key",
-        model: "test-model",
-      },
-      zai: {
-        api_url: "https://zai.test-api-url.com",
-        api_key: "test-zai-key",
-        model: "test-zai-model",
-      },
-    }),
-  },
+  getConfig: jest.fn(() => ({
+    gemini: {
+      api_url: "https://test-api-url.com",
+      api_key: "test-api-key",
+      model: "test-model",
+    },
+    zai: {
+      api_url: "https://zai.test-api-url.com",
+      api_key: "test-zai-key",
+      model: "test-zai-model",
+    },
+  })),
   LLM_PROVIDER: "gemini",
 }));
 
@@ -41,10 +39,10 @@ describe("GeminiLlmService", () => {
     });
 
     it("should throw when the Gemini API key is missing", () => {
-      // Temporarily override configSecret to omit the api_key.
-      const { configSecret } = require("../../src/config");
-      const original = configSecret.value;
-      configSecret.value = () => ({
+      const { getConfig } = jest.requireMock("../../src/config") as {
+        getConfig: jest.Mock;
+      };
+      getConfig.mockReturnValueOnce({
         gemini: { api_url: "https://test-api-url.com", api_key: "", model: "test-model" },
         zai: { api_url: "", api_key: "", model: "" },
       });
@@ -52,8 +50,6 @@ describe("GeminiLlmService", () => {
       expect(() => new GeminiLlmService()).toThrow(
         "Gemini API key not found"
       );
-
-      configSecret.value = original;
     });
   });
 

--- a/japanese-alchemy-hosting/functions/test/services/llmRetryService.test.ts
+++ b/japanese-alchemy-hosting/functions/test/services/llmRetryService.test.ts
@@ -5,8 +5,7 @@ import { createLlmService } from "../../src/services/llmService";
 
 // Mock the config so services can be instantiated without real secrets.
 jest.mock("../../src/config", () => ({
-  configSecret: {
-    value: () => ({
+  getConfig: () => ({
       gemini: {
         api_url: "https://test-gemini.com",
         api_key: "test-gemini-key",
@@ -18,7 +17,6 @@ jest.mock("../../src/config", () => ({
         model: "test-zai-model",
       },
     }),
-  },
   LLM_PROVIDER: "gemini",
   LLM_CHAIN: ["gemini", "zai"] as const,
 }));

--- a/japanese-alchemy-hosting/functions/test/services/llmRetryService.test.ts
+++ b/japanese-alchemy-hosting/functions/test/services/llmRetryService.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, jest } from "@jest/globals";
+import * as functions from "firebase-functions";
+import { shouldRetry, LlmServiceChain } from "../../src/services/llmRetryService";
+import { createLlmService } from "../../src/services/llmService";
+
+// Mock the config so services can be instantiated without real secrets.
+jest.mock("../../src/config", () => ({
+  configSecret: {
+    value: () => ({
+      gemini: {
+        api_url: "https://test-gemini.com",
+        api_key: "test-gemini-key",
+        model: "test-gemini-model",
+      },
+      zai: {
+        api_url: "https://test-zai.com",
+        api_key: "test-zai-key",
+        model: "test-zai-model",
+      },
+    }),
+  },
+  LLM_PROVIDER: "gemini",
+  LLM_CHAIN: ["gemini", "zai"] as const,
+}));
+
+describe("shouldRetry", () => {
+  describe("HttpsError with HTTP status in message", () => {
+    it("returns true for 429 Too Many Requests", () => {
+      const error = new functions.https.HttpsError(
+        "internal",
+        "Gemini API error: 429 Too Many Requests"
+      );
+      expect(shouldRetry(error)).toBe(true);
+    });
+
+    it("returns true for 500 Internal Server Error", () => {
+      const error = new functions.https.HttpsError(
+        "internal",
+        "Gemini API error: 500 Internal Server Error"
+      );
+      expect(shouldRetry(error)).toBe(true);
+    });
+
+    it("returns true for 502 Bad Gateway", () => {
+      const error = new functions.https.HttpsError(
+        "internal",
+        "ZAI API error: 502 Bad Gateway"
+      );
+      expect(shouldRetry(error)).toBe(true);
+    });
+
+    it("returns true for 503 Service Unavailable", () => {
+      const error = new functions.https.HttpsError(
+        "internal",
+        "Gemini API error: 503 Service Unavailable"
+      );
+      expect(shouldRetry(error)).toBe(true);
+    });
+
+    it("returns false for 400 Bad Request", () => {
+      const error = new functions.https.HttpsError(
+        "invalid-argument",
+        "Gemini API error: 400 Bad Request"
+      );
+      expect(shouldRetry(error)).toBe(false);
+    });
+
+    it("returns false for 401 Unauthorized", () => {
+      const error = new functions.https.HttpsError(
+        "unauthenticated",
+        "Gemini API error: 401 Unauthorized"
+      );
+      expect(shouldRetry(error)).toBe(false);
+    });
+
+    it("returns false for 403 Forbidden", () => {
+      const error = new functions.https.HttpsError(
+        "permission-denied",
+        "ZAI API error: 403 Forbidden"
+      );
+      expect(shouldRetry(error)).toBe(false);
+    });
+
+    it("returns false for plain internal error without status", () => {
+      const error = new functions.https.HttpsError(
+        "internal",
+        "Unknown error"
+      );
+      expect(shouldRetry(error)).toBe(false);
+    });
+  });
+
+  describe("TypeError / network errors", () => {
+    it("returns true for TypeError", () => {
+      expect(shouldRetry(new TypeError("fetch failed"))).toBe(true);
+    });
+
+    it("returns true for TypeError with connection refused", () => {
+      expect(shouldRetry(new TypeError("connect ECONNREFUSED"))).toBe(true);
+    });
+
+    it("returns true for Error with ETIMEDOUT", () => {
+      expect(shouldRetry(new Error("ETIMEDOUT"))).toBe(true);
+    });
+
+    it("returns true for Error with ECONNREFUSED", () => {
+      expect(shouldRetry(new Error("ECONNREFUSED"))).toBe(true);
+    });
+
+    it("returns true for Error with ENOTFOUND", () => {
+      expect(shouldRetry(new Error("ENOTFOUND"))).toBe(true);
+    });
+
+    it("returns false for generic Error", () => {
+      expect(shouldRetry(new Error("Some random error"))).toBe(false);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns false for null", () => {
+      expect(shouldRetry(null)).toBe(false);
+    });
+
+    it("returns false for undefined", () => {
+      expect(shouldRetry(undefined)).toBe(false);
+    });
+
+    it("returns false for a string", () => {
+      expect(shouldRetry("error")).toBe(false);
+    });
+  });
+});
+
+describe("createLlmService factory", () => {
+  it("returns LlmServiceChain when called without argument", () => {
+    const service = createLlmService();
+    expect(service).toBeInstanceOf(LlmServiceChain);
+  });
+
+  it("returns GeminiLlmService when called with 'gemini'", () => {
+    const service = createLlmService("gemini");
+    expect(service).not.toBeInstanceOf(LlmServiceChain);
+  });
+
+  it("returns ZaiLlmService when called with 'zai'", () => {
+    const service = createLlmService("zai");
+    expect(service).not.toBeInstanceOf(LlmServiceChain);
+  });
+});

--- a/japanese-alchemy-hosting/functions/test/services/zaiLlmService.test.ts
+++ b/japanese-alchemy-hosting/functions/test/services/zaiLlmService.test.ts
@@ -2,12 +2,10 @@ import { beforeEach, describe, expect, it, jest } from "@jest/globals";
 import { ZaiLlmService } from "../../src/services/zaiLlmService";
 
 jest.mock("../../src/config", () => ({
-  configSecret: {
-    value: () => ({
+  getConfig: () => ({
       gemini: { api_url: "https://gemini.example", api_key: "gemini-key", model: "gemini-3-flash-preview" },
       zai: { api_url: "https://zai.example", api_key: "zai-key", model: "GLM-5.3-Flash" },
     }),
-  },
   LLM_PROVIDER: "zai",
 }));
 

--- a/japanese-alchemy-hosting/functions/test/v1/explainCallable.test.ts
+++ b/japanese-alchemy-hosting/functions/test/v1/explainCallable.test.ts
@@ -34,10 +34,17 @@ describe("explainHandler", () => {
     expect(mockChatCompletion).toHaveBeenCalledWith(SYSTEM_PROMPT_V2, "テストです");
   });
 
-  it.each([undefined, "gemini", "zai"])("always selects Gemini for ai=%s", async (ai) => {
-    await explainHandler({ data: { content: "テストです", ...(ai && { ai }) } } as any);
-
+  it("uses the ai parameter when provided", async () => {
+    await explainHandler({ data: { content: "テストです", ai: "gemini" } } as any);
     expect(mockCreateLlmService).toHaveBeenCalledWith("gemini");
+
+    await explainHandler({ data: { content: "テストです", ai: "zai" } } as any);
+    expect(mockCreateLlmService).toHaveBeenCalledWith("zai");
+  });
+
+  it("uses the chain when ai is not provided", async () => {
+    await explainHandler({ data: { content: "テストです" } } as any);
+    expect(mockCreateLlmService).toHaveBeenCalledWith(undefined);
   });
 
   it("selects v1 when prompt is v1", async () => {

--- a/japanese-alchemy-hosting/functions/test/v1/llmStreamDeltas.test.ts
+++ b/japanese-alchemy-hosting/functions/test/v1/llmStreamDeltas.test.ts
@@ -44,4 +44,22 @@ describe("consumeLlmStream", () => {
     expect(result.completed).toBe(false);
     expect(result.usage).toBeUndefined();
   });
+
+  it("forwards Bedrock Responses text deltas and completes from response.completed", async () => {
+    const onDelta = jest.fn();
+    const result = await consumeLlmStream(responseFromFrames([
+      'data: {"type":"response.output_text.delta","delta":"日本"}\n\n',
+      'data: {"type":"response.output_text.delta","delta":"語"}\n\n',
+      'data: {"type":"response.completed","response":{"model":"google.gemma-4-31b","status":"completed","usage":{"input_tokens":10,"output_tokens":20,"total_tokens":30}}}\n\n',
+    ]), onDelta as (content: string) => void);
+
+    expect(onDelta).toHaveBeenNthCalledWith(1, "日本");
+    expect(onDelta).toHaveBeenNthCalledWith(2, "語");
+    expect(result).toEqual({
+      usage: { prompt_tokens: 10, completion_tokens: 20, total_tokens: 30 },
+      responseModel: "google.gemma-4-31b",
+      finishReason: "stop",
+      completed: true,
+    });
+  });
 });


### PR DESCRIPTION
## What problem does this solve?

J-Buddy could not use AWS Bedrock as a reliable analysis provider: its two OpenAI-compatible endpoint shapes were not normalized, Responses streaming produced no callable chunks, and provider failures had no shared fallback path.

Discord Discussion URL: No prior Discord discussion; this PR consolidates the Bedrock provider work and its runtime fixes.

## At a Glance

```
+-------------------------------------+
|          Callable handler           |
+------------------+------------------+
                   |
                   v
+------------------+------------------+
|         LLM fallback chain          |
+------------------+------------------+
                   |
                   v
+------------------+------------------+
| Bedrock adapter (Responses or Chat) |
+------------------+------------------+
                   |
                   v
+------------------+------------------+
|            Provider API             |
+-------------------------------------+
```

## Prior Art & Industry Research

- [OpenAI Responses streaming events](https://developers.openai.com/api/reference/resources/responses/streaming-events) defines `response.output_text.delta` and `response.completed`, which the Bedrock Responses endpoint follows.
- [Amazon Bedrock Responses streaming guidance](https://docs.aws.amazon.com/bedrock/latest/userguide/web-search.html) demonstrates consuming incremental Responses events.

## Proposed Solution

- Add Bedrock adapters for both `/openai/v1/responses` and `/openai/v1/chat/completions` while preserving the existing LLM interface.
- Stream Bedrock Responses with `stream: true` and translate its delta and completion events into the callable stream contract.
- Use `bedrock_response` and `bedrock_chat` consistently in request selection, fallback configuration, secrets, and tests.
- Keep Firebase secret wiring inside the configuration module; provider modules consume typed configuration through `getConfig()`.

## Why this approach?

It preserves one callable-stream interface across providers while allowing Bedrock's distinct protocol to stay localized in its adapter and stream parser. The tradeoff is provider-specific event handling in the shared parser; regression tests cover both Chat Completions and Responses event shapes.

## Alternatives Considered

- Treat Responses events as Chat Completions chunks: rejected because Responses puts text in top-level `delta` and terminal metadata under `response`.
- Use non-streaming Responses calls: rejected because the extension requires progressive callable chunks.
- Expose Firebase's secret parameter to each provider: rejected because it spreads deployment-specific configuration access across runtime modules.

## Validation

- [x] `npm run build`
- [x] `npm test -- --runInBand` (19 suites, 191 tests)
- [x] Added request-shape, Responses SSE, configuration, and fallback regression coverage
- [ ] Live Bedrock invocation was not run locally because it requires configured credentials.
